### PR TITLE
fix: discard bogus 24h price deltas, hide express trading banner

### DIFF
--- a/src/domain/synthetics/tokens/use24hPriceDeltaMap.ts
+++ b/src/domain/synthetics/tokens/use24hPriceDeltaMap.ts
@@ -53,6 +53,11 @@ export function use24hPriceDeltaMap(
           }
 
           const deltaPrice = tokenDelta.close - tokenDelta.open;
+
+          if (tokenDelta.open <= 0 || Math.abs(deltaPrice / tokenDelta.open) > 10) {
+            return [tokenAddress, undefined];
+          }
+
           const deltaPercentage = (deltaPrice * 100) / tokenDelta.open;
           const deltaPercentageStr =
             deltaPercentage > 0 ? `+${deltaPercentage.toFixed(2)}%` : `${deltaPercentage.toFixed(2)}%`;

--- a/src/pages/SyntheticsPage/SyntheticsPage.tsx
+++ b/src/pages/SyntheticsPage/SyntheticsPage.tsx
@@ -341,7 +341,7 @@ export function SyntheticsPage(p: Props) {
       <ChartHeader />
       <div className="flex gap-8 pt-0 max-lg:flex-col lg:grow">
         <div className="Exchange-left flex grow flex-col gap-8">
-          <OneClickPromoBanner openSettings={openSettings} />
+          {/* <OneClickPromoBanner openSettings={openSettings} /> */}
           <Chart />
           {!isTablet && (
             <div className="flex grow flex-col overflow-hidden rounded-8 border border-slate-800 bg-slate-750" data-qa="trade-table-large">


### PR DESCRIPTION
Skip 24h price delta calculation when open price is zero/negative or the change exceeds 1000%, which happens when the keeper returns raw contract-scale prices for candle open/low values.

Comment out the OneClickPromoBanner (express trading) from the trade page.