### PR TITLE
fix: trade history silently dropping all executed orders

### DIFF
--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -14,6 +14,15 @@ A user can open and close leveraged trading positions with clear feedback, relia
 
 Fixed squid indexer to populate pnlUsd on trade actions, extract fees from PositionFeesCollected events, and resolve int256/uint256 type mismatch for maxCapital. Fixed frontend leaderboard query params. Trade history and leaderboard now display accurate data.
 
+## Current Milestone: v1.12 WebSocket Price Streaming
+
+**Goal:** Replace HTTP polling with Pyth Hermes WebSocket for real-time price updates across keeper and frontend, fix chart staleness.
+
+**Target features:**
+- Keeper WebSocket streaming from Pyth (replace 2s HTTP polling in candleCollector)
+- Frontend WebSocket from keeper (replace 1s polling of /prices/tickers and /prices/candles)
+- TradingView real-time bar updates using mark price (fix chart staleness)
+
 **All prior milestones:**
 - v1.0 Fix Buy GM Flow (2026-02-21) — deposit execution pipeline
 - v1.1 Full Trading Experience (2026-02-22) — all 6 markets, positions, limit orders
@@ -168,4 +177,4 @@ Fixed squid indexer to populate pnlUsd on trade actions, extract fees from Posit
 | Type-aware collateralDeltaAmount extraction | int256 for increase, uint256 for decrease | ✓ Good — fixed maxCapital |
 
 ---
-*Last updated: 2026-03-05 after v1.11 milestone*
+*Last updated: 2026-03-05 after v1.12 milestone start*

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -1,0 +1,85 @@
+# Requirements: 0xMarkets v1.12 WebSocket Price Streaming
+
+**Defined:** 2026-03-05
+**Core Value:** Real-time price updates across the entire interface — mark prices, chart candles, and PnL — with sub-second latency via WebSocket streaming.
+
+## v1.12 Requirements
+
+### Infrastructure
+
+- [ ] **INFRA-01**: TLS termination configured on DO droplet for secure WebSocket connections (wss://)
+- [ ] **INFRA-02**: DNS subdomain (e.g., keeper.0xmarkets.io) pointing to DO droplet for direct WS access
+
+### Keeper Streaming
+
+- [ ] **KSTR-01**: Keeper connects to Pyth Hermes SSE endpoint, replacing 2s HTTP polling in candleCollector
+- [ ] **KSTR-02**: In-memory price cache updated by SSE stream, serving all /prices/* endpoints from cache instead of per-request Hermes calls
+- [ ] **KSTR-03**: SSE connection auto-reconnects on disconnect (including Hermes 24h auto-close) with exponential backoff
+
+### Keeper WebSocket Server
+
+- [ ] **KWS-01**: WebSocket server mounted on existing Express HTTP server (port 37017) using `ws` library
+- [ ] **KWS-02**: Ticker updates broadcast to all connected clients on each SSE price update
+- [ ] **KWS-03**: In-progress candle updates broadcast at ~200ms intervals with current OHLC state
+- [ ] **KWS-04**: Server-side heartbeat ping/pong detects and drops dead connections
+- [ ] **KWS-05**: Backpressure handling — skip or drop messages for slow clients to prevent memory exhaustion
+
+### Frontend WebSocket Client
+
+- [ ] **FWS-01**: Frontend establishes WebSocket connection to keeper with auto-reconnect and exponential backoff
+- [ ] **FWS-02**: Mark prices update via WebSocket push, replacing 1s HTTP polling of /prices/tickers
+- [ ] **FWS-03**: TradingView chart receives real-time bar updates via WebSocket, replacing 1s HTTP polling of /prices/candles
+- [ ] **FWS-04**: HTTP polling remains as fallback when WebSocket is unavailable or disconnected
+- [ ] **FWS-05**: Timestamp gating prevents stale HTTP responses from overwriting fresher WebSocket data
+- [ ] **FWS-06**: Connection status indicator visible in UI (connected/reconnecting/stale)
+
+## Future Requirements
+
+### Performance
+
+- **PERF-01**: Process isolation — run WebSocket server in separate container from critical keeper loop
+- **PERF-02**: Sub-second PnL recalculation reactive to WebSocket price updates
+
+### Resilience
+
+- **RESL-01**: Client-side stale price detection with visual warning after N seconds without update
+
+## Out of Scope
+
+| Feature | Reason |
+|---------|--------|
+| Direct browser-to-Hermes connection | Exposes Pyth API key to clients |
+| Order book WebSocket | Oracle-based pricing, no order book |
+| Client-side candle aggregation | Keeper is source of truth for candles |
+| Multi-tab coordination | Complexity not justified for testnet |
+| WebSocket authentication | Testnet — no sensitive data exposed |
+
+## Traceability
+
+| Requirement | Phase | Status |
+|-------------|-------|--------|
+| INFRA-01 | — | Pending |
+| INFRA-02 | — | Pending |
+| KSTR-01 | — | Pending |
+| KSTR-02 | — | Pending |
+| KSTR-03 | — | Pending |
+| KWS-01 | — | Pending |
+| KWS-02 | — | Pending |
+| KWS-03 | — | Pending |
+| KWS-04 | — | Pending |
+| KWS-05 | — | Pending |
+| FWS-01 | — | Pending |
+| FWS-02 | — | Pending |
+| FWS-03 | — | Pending |
+| FWS-04 | — | Pending |
+| FWS-05 | — | Pending |
+| FWS-06 | — | Pending |
+
+**Coverage:**
+- v1.12 requirements: 16 total
+- Mapped to phases: 0
+- Unmapped: 16
+
+---
+*Requirements defined: 2026-03-05*
+*Last updated: 2026-03-05 after initial definition*

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -58,28 +58,28 @@
 
 | Requirement | Phase | Status |
 |-------------|-------|--------|
-| INFRA-01 | — | Pending |
-| INFRA-02 | — | Pending |
-| KSTR-01 | — | Pending |
-| KSTR-02 | — | Pending |
-| KSTR-03 | — | Pending |
-| KWS-01 | — | Pending |
-| KWS-02 | — | Pending |
-| KWS-03 | — | Pending |
-| KWS-04 | — | Pending |
-| KWS-05 | — | Pending |
-| FWS-01 | — | Pending |
-| FWS-02 | — | Pending |
-| FWS-03 | — | Pending |
-| FWS-04 | — | Pending |
-| FWS-05 | — | Pending |
-| FWS-06 | — | Pending |
+| INFRA-01 | Phase 40 | Pending |
+| INFRA-02 | Phase 40 | Pending |
+| KSTR-01 | Phase 40 | Pending |
+| KSTR-02 | Phase 40 | Pending |
+| KSTR-03 | Phase 40 | Pending |
+| KWS-01 | Phase 41 | Pending |
+| KWS-02 | Phase 41 | Pending |
+| KWS-03 | Phase 41 | Pending |
+| KWS-04 | Phase 41 | Pending |
+| KWS-05 | Phase 41 | Pending |
+| FWS-01 | Phase 42 | Pending |
+| FWS-02 | Phase 42 | Pending |
+| FWS-03 | Phase 42 | Pending |
+| FWS-04 | Phase 42 | Pending |
+| FWS-05 | Phase 42 | Pending |
+| FWS-06 | Phase 42 | Pending |
 
 **Coverage:**
 - v1.12 requirements: 16 total
-- Mapped to phases: 0
-- Unmapped: 16
+- Mapped to phases: 16
+- Unmapped: 0
 
 ---
 *Requirements defined: 2026-03-05*
-*Last updated: 2026-03-05 after initial definition*
+*Last updated: 2026-03-05 — traceability updated with phase mappings*

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -14,6 +14,7 @@
 - ✅ **v1.9 Event Indexer** — Phases 31-34
 - ✅ **v1.10 E2E Verification** — Phases 35-37 ([shipped 2026-03-05](milestones/v1.10-ROADMAP.md))
 - ✅ **v1.11 Trade History & Leaderboard Fix** — Phases 38-39 ([shipped 2026-03-05](milestones/v1.11-ROADMAP.md))
+- 🚧 **v1.12 WebSocket Price Streaming** — Phases 40-42 (in progress)
 
 ## Phases
 
@@ -34,16 +35,75 @@
 
 </details>
 
+### 🚧 v1.12 WebSocket Price Streaming (In Progress)
+
+**Milestone Goal:** Replace HTTP polling with WebSocket streaming for real-time price updates across keeper and frontend
+
+- [ ] **Phase 40: Infrastructure + Keeper Hermes SSE** — TLS endpoint on DO droplet and streaming price source replacing HTTP polling
+- [ ] **Phase 41: Keeper WebSocket Server** — Broadcast ticker and candle updates to connected frontends over WebSocket
+- [ ] **Phase 42: Frontend WebSocket Integration** — Real-time mark prices and chart bars via WebSocket with HTTP fallback
+
+## Phase Details
+
+### Phase 40: Infrastructure + Keeper Hermes SSE
+**Goal**: Keeper receives real-time prices from Pyth Hermes via SSE streaming and serves them from an in-memory cache, with TLS infrastructure ready for direct frontend WebSocket connections
+**Depends on**: Nothing (first phase of v1.12)
+**Requirements**: INFRA-01, INFRA-02, KSTR-01, KSTR-02, KSTR-03
+**Success Criteria** (what must be TRUE):
+  1. Frontend can establish a secure wss:// connection to the keeper subdomain (e.g., keeper.0xmarkets.io) without mixed-content errors
+  2. Keeper receives price updates from Pyth Hermes via SSE stream instead of 2-second HTTP polling
+  3. All existing /prices/* HTTP endpoints return data from the in-memory SSE-fed cache (no per-request Hermes calls)
+  4. SSE connection automatically recovers after disconnect (including Hermes 24h auto-close) without manual intervention
+**Plans**: TBD
+
+Plans:
+- [ ] 40-01: TBD
+- [ ] 40-02: TBD
+
+### Phase 41: Keeper WebSocket Server
+**Goal**: Connected clients receive real-time ticker and candle data pushed from the keeper over WebSocket
+**Depends on**: Phase 40
+**Requirements**: KWS-01, KWS-02, KWS-03, KWS-04, KWS-05
+**Success Criteria** (what must be TRUE):
+  1. A WebSocket client (e.g., wscat) can connect to the keeper and receive continuous ticker price updates
+  2. In-progress candle OHLC updates arrive at approximately 200ms intervals
+  3. Dead connections (no pong response) are detected and dropped within 30-60 seconds
+  4. Slow or stalled clients do not cause keeper memory growth — messages are skipped when buffer exceeds threshold
+**Plans**: TBD
+
+Plans:
+- [ ] 41-01: TBD
+- [ ] 41-02: TBD
+
+### Phase 42: Frontend WebSocket Integration
+**Goal**: Users see real-time mark prices and chart updates in the interface with sub-second latency, with transparent fallback to HTTP polling when WebSocket is unavailable
+**Depends on**: Phase 41
+**Requirements**: FWS-01, FWS-02, FWS-03, FWS-04, FWS-05, FWS-06
+**Success Criteria** (what must be TRUE):
+  1. Mark prices on the trade page update in real-time without visible polling delay (sub-second latency)
+  2. TradingView chart updates with new bars in real-time — no staleness or gaps while the page is open
+  3. If the WebSocket disconnects, prices continue updating via HTTP polling fallback within 5 seconds
+  4. A connection status indicator shows connected/reconnecting/stale state in the UI
+  5. Stale HTTP responses never overwrite fresher WebSocket data (timestamp-gated updates)
+**Plans**: TBD
+
+Plans:
+- [ ] 42-01: TBD
+- [ ] 42-02: TBD
+
 ## Progress
+
+**Execution Order:**
+Phases execute in numeric order: 40 -> 41 -> 42
 
 | Phase | Milestone | Plans Complete | Status | Completed |
 |-------|-----------|----------------|--------|-----------|
 | 38. Squid Fixes & Redeployment | v1.11 | 1/1 | Complete | 2026-03-05 |
 | 39. Frontend Verification & Fixes | v1.11 | 1/1 | Complete | 2026-03-05 |
-| 35. Trigger Order Fix | v1.10 | 1/1 | Complete | 2026-03-04 |
-| 36. E2E Test Suite | v1.10 | 1/1 | Complete | 2026-03-04 |
-| 37. Frontend Verification | v1.10 | 2/2 | Complete | 2026-03-05 |
+| 40. Infrastructure + Keeper Hermes SSE | v1.12 | 0/TBD | Not started | - |
+| 41. Keeper WebSocket Server | v1.12 | 0/TBD | Not started | - |
+| 42. Frontend WebSocket Integration | v1.12 | 0/TBD | Not started | - |
 
 ---
 *Created: 2026-03-04*
-*Updated: 2026-03-05 — v1.11 milestone shipped*
+*Updated: 2026-03-05 — v1.12 roadmap created*

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,15 +1,17 @@
 ---
 gsd_state_version: 1.0
-milestone: "v1.12"
-milestone_name: "WebSocket Price Streaming"
-status: ready_to_plan
-stopped_at: "Phase 40 ready to plan"
-last_updated: "2026-03-05"
+milestone: v1.12
+milestone_name: WebSocket Price Streaming
+status: planning
+stopped_at: Phase 40 context gathered
+last_updated: "2026-03-06T01:42:17.814Z"
+last_activity: 2026-03-05 — Roadmap created for v1.12 (3 phases, 16 requirements)
 progress:
-  total_phases: 42
-  completed_phases: 39
-  total_plans: 70
-  completed_plans: 70
+  total_phases: 3
+  completed_phases: 0
+  total_plans: 0
+  completed_plans: 0
+  percent: 93
 ---
 
 # Project State
@@ -71,6 +73,6 @@ None.
 
 ## Session Continuity
 
-Last session: 2026-03-05
-Stopped at: Roadmap created for v1.12
+Last session: 2026-03-06T01:42:17.812Z
+Stopped at: Phase 40 context gathered
 Next: `/gsd:plan-phase 40`

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,8 +1,8 @@
 ---
 gsd_state_version: 1.0
-milestone: null
-milestone_name: null
-status: idle
+milestone: "v1.12"
+milestone_name: "WebSocket Price Streaming"
+status: defining_requirements
 stopped_at: null
 last_updated: "2026-03-05"
 progress:
@@ -19,15 +19,14 @@ progress:
 See: .planning/PROJECT.md (updated 2026-03-05)
 
 **Core value:** A user can open and close leveraged trading positions with clear feedback, reliable execution, and access to all configured markets.
-**Current focus:** Planning next milestone
+**Current focus:** v1.12 WebSocket Price Streaming
 
 ## Current Position
 
-v1.11 Trade History & Leaderboard Fix shipped. No active milestone.
-
-### Last Shipped
-- v1.11: Fixed squid pnlUsd enrichment, fee extraction, maxCapital calculation, and leaderboard query params
-- Trade history and leaderboard now display accurate data against live squid
+Phase: Not started (defining requirements)
+Plan: —
+Status: Defining requirements
+Last activity: 2026-03-05 — Milestone v1.12 started
 
 ## Accumulated Context
 
@@ -37,6 +36,7 @@ v1.11 Trade History & Leaderboard Fix shipped. No active milestone.
 - JPY/USD Pyth Lazer oracle data gap — testnet infrastructure, not code
 - Shared wallet nonce conflict between keeper-service and order-execution-keeper
 - abis.ts has incorrect getAccountOrders ABI (uint256 enums, phantom updatedAtBlock)
+- Chart candle data lags mark price by 0-2s due to keeper's 2s Pyth HTTP polling interval
 
 ### Server State
 
@@ -59,5 +59,5 @@ None.
 ## Session Continuity
 
 Last session: 2026-03-05
-Stopped at: v1.11 milestone completed
-Next: /gsd:new-milestone
+Stopped at: Defining v1.12 requirements
+Next: Define requirements → create roadmap

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,11 +2,11 @@
 gsd_state_version: 1.0
 milestone: "v1.12"
 milestone_name: "WebSocket Price Streaming"
-status: defining_requirements
-stopped_at: null
+status: ready_to_plan
+stopped_at: "Phase 40 ready to plan"
 last_updated: "2026-03-05"
 progress:
-  total_phases: 39
+  total_phases: 42
   completed_phases: 39
   total_plans: 70
   completed_plans: 70
@@ -19,14 +19,27 @@ progress:
 See: .planning/PROJECT.md (updated 2026-03-05)
 
 **Core value:** A user can open and close leveraged trading positions with clear feedback, reliable execution, and access to all configured markets.
-**Current focus:** v1.12 WebSocket Price Streaming
+**Current focus:** v1.12 Phase 40 — Infrastructure + Keeper Hermes SSE
 
 ## Current Position
 
-Phase: Not started (defining requirements)
-Plan: —
-Status: Defining requirements
-Last activity: 2026-03-05 — Milestone v1.12 started
+Phase: 40 of 42 (Infrastructure + Keeper Hermes SSE)
+Plan: 0 of TBD in current phase
+Status: Ready to plan
+Last activity: 2026-03-05 — Roadmap created for v1.12 (3 phases, 16 requirements)
+
+Progress: [██████████████████░░] 93% (39/42 phases)
+
+## Performance Metrics
+
+**Velocity:**
+- Total plans completed: 70
+- Total execution time: ~12 milestones across 13 days
+
+**Recent Trend:**
+- v1.11: 2 plans in ~30 min
+- v1.10: 4 plans in ~2.5 hours
+- Trend: Stable
 
 ## Accumulated Context
 
@@ -35,14 +48,13 @@ Last activity: 2026-03-05 — Milestone v1.12 started
 - WETH/USD pool at 100% reserve capacity — blocks new position creation on that market
 - JPY/USD Pyth Lazer oracle data gap — testnet infrastructure, not code
 - Shared wallet nonce conflict between keeper-service and order-execution-keeper
-- abis.ts has incorrect getAccountOrders ABI (uint256 enums, phantom updatedAtBlock)
-- Chart candle data lags mark price by 0-2s due to keeper's 2s Pyth HTTP polling interval
+- Chart candle data lags mark price by 0-2s due to keeper's 2s Pyth HTTP polling interval (target of this milestone)
 
 ### Server State
 
 - All services deployed on DO droplet (142.93.203.222)
 - keeper-service: port 37017, order-execution-keeper: port 37018, data-verification: port 37019
-- Squid redeployed 2026-03-05 with pnlUsd + fee + maxCapital fixes, fully re-indexed
+- TLS status on droplet: unknown — Phase 40 must audit before choosing TLS approach
 
 ### Pending Todos
 
@@ -50,7 +62,8 @@ None.
 
 ### Blockers/Concerns
 
-None.
+- DO droplet TLS status unknown — need to audit nginx/Caddy before Phase 40 planning
+- Pyth Pro API key concurrent connection support (Lazer WS + Hermes SSE) unverified
 
 ## Decisions
 
@@ -59,5 +72,5 @@ None.
 ## Session Continuity
 
 Last session: 2026-03-05
-Stopped at: Defining v1.12 requirements
-Next: Define requirements → create roadmap
+Stopped at: Roadmap created for v1.12
+Next: `/gsd:plan-phase 40`

--- a/.planning/phases/40-infrastructure-keeper-hermes-sse/40-CONTEXT.md
+++ b/.planning/phases/40-infrastructure-keeper-hermes-sse/40-CONTEXT.md
@@ -16,12 +16,13 @@ TLS infrastructure on the DO droplet enabling secure WebSocket connections from 
 ### Stack constraints
 - Frontend hosted on Vercel — cannot proxy WebSocket (Vercel serverless limitation)
 - Keeper runs on DO droplet (142.93.203.222) via Docker Compose
-- TLS and reverse proxy tooling must work within this Vercel + DO setup
 - Direct wss:// from browser to DO droplet required (no Vercel middleman)
+- DNS managed via Cloudflare — user has full access and can create subdomains
+- User is not familiar with TLS or nginx — prefer Cloudflare-managed TLS (orange-cloud proxy) to avoid manual cert management on the droplet
+- Cloudflare proxy handles TLS termination + WebSocket proxying natively
 
 ### Claude's Discretion
-- TLS approach (Caddy vs nginx+certbot) — choose what's simplest for DO + Docker
-- Subdomain naming convention (keeper.0xmarkets.io or similar)
+- Subdomain naming convention (keeper.0xmarkets.io or similar) — user will create the DNS record
 - SSE vs WebSocket for Pyth Hermes connection — choose based on library support and reconnection behavior
 - Cache architecture — how SSE stream feeds into existing pricesController and candleCollector
 - Deployment/rollback strategy

--- a/.planning/phases/40-infrastructure-keeper-hermes-sse/40-CONTEXT.md
+++ b/.planning/phases/40-infrastructure-keeper-hermes-sse/40-CONTEXT.md
@@ -1,0 +1,73 @@
+# Phase 40: Infrastructure + Keeper Hermes SSE - Context
+
+**Gathered:** 2026-03-05
+**Status:** Ready for planning
+
+<domain>
+## Phase Boundary
+
+TLS infrastructure on the DO droplet enabling secure WebSocket connections from the Vercel-hosted frontend, plus Pyth Hermes SSE streaming replacing HTTP polling in the keeper-service. All existing /prices/* endpoints serve from an SSE-fed in-memory cache.
+
+</domain>
+
+<decisions>
+## Implementation Decisions
+
+### Stack constraints
+- Frontend hosted on Vercel — cannot proxy WebSocket (Vercel serverless limitation)
+- Keeper runs on DO droplet (142.93.203.222) via Docker Compose
+- TLS and reverse proxy tooling must work within this Vercel + DO setup
+- Direct wss:// from browser to DO droplet required (no Vercel middleman)
+
+### Claude's Discretion
+- TLS approach (Caddy vs nginx+certbot) — choose what's simplest for DO + Docker
+- Subdomain naming convention (keeper.0xmarkets.io or similar)
+- SSE vs WebSocket for Pyth Hermes connection — choose based on library support and reconnection behavior
+- Cache architecture — how SSE stream feeds into existing pricesController and candleCollector
+- Deployment/rollback strategy
+
+</decisions>
+
+<specifics>
+## Specific Ideas
+
+No specific requirements — user deferred all implementation choices to Claude's discretion given the established stack context.
+
+</specifics>
+
+<code_context>
+## Existing Code Insights
+
+### Reusable Assets
+- `@pythnetwork/hermes-client` (v2.1.0): Already a dependency, has SSE/streaming support
+- `candleCollector.ts`: 2s polling loop with in-memory OHLC candles + Prisma DB flush — SSE replaces the polling
+- `pricesController.ts`: Three endpoints (getTickers, get24hPrices, getPriceBySymbol) each make independent Hermes HTTP calls — all should read from shared cache
+- `pythOracle.ts`: Scanner batch-fetches prices from Hermes — can also read from cache
+- `httpServer.ts`: Express server on port 37017 — WebSocket server will mount here (Phase 41)
+- `healthState.ts`: Mutable singleton for health status — extend with SSE connection state
+
+### Established Patterns
+- Pino structured logging with child loggers per module
+- Docker Compose orchestration with env vars for all config
+- Express HTTP server with CORS middleware
+- Lazy-initialized singleton clients (getHermesClient pattern)
+
+### Integration Points
+- `docker-compose.yml`: keeper-service exposes port 37017 — TLS proxy sits in front
+- `PYTH_PRICE_FEED_IDS`: Duplicated in candleCollector.ts and pricesController.ts — consolidate into shared config
+- `currentCandles` export: candlesController reads from candleCollector's in-memory map
+- DNS: 0xmarkets.io domain — needs subdomain record pointing to DO droplet
+
+</code_context>
+
+<deferred>
+## Deferred Ideas
+
+None — discussion stayed within phase scope
+
+</deferred>
+
+---
+
+*Phase: 40-infrastructure-keeper-hermes-sse*
+*Context gathered: 2026-03-05*

--- a/.planning/research/ARCHITECTURE.md
+++ b/.planning/research/ARCHITECTURE.md
@@ -1,322 +1,330 @@
-# Architecture: Liquidation Readiness Integration
+# Architecture Patterns
 
-**Domain:** Perpetual futures keeper service — contract bug fix + liquidation pipeline verification and optimization
-**Researched:** 2026-02-27
-**Confidence:** HIGH (based on direct source code analysis of all integration points)
+**Domain:** WebSocket price streaming for perpetual futures trading interface
+**Researched:** 2026-03-05
 
-## Current System Architecture
-
-Two independent keeper processes run on a single DigitalOcean droplet (142.93.203.222) via Docker Compose, sharing a wallet and RPC but otherwise isolated:
+## Current Architecture (Before WebSocket)
 
 ```
-docker-compose.yml (/opt/0xmarkets/)
-  |
-  +-- postgres (postgres:16)
-  |     - Two databases: keeper_service, order_execution_keeper (order_execution_keeper unused post-v1.5)
-  |     - Volume: pgdata
-  |
-  +-- keeper-service (port 37017)            <-- FOCUS OF v1.7
-  |     - scanner.ts: scans all positions for liquidatability
-  |     - riskEngine.ts: secondary risk scoring (currently bypassed by scanner)
-  |     - executor.ts: calls LiquidationHandler.executeLiquidation()
-  |     - confirmator.ts: watches EventLog2 for OrderExecuted confirmation
-  |     - positionFetcher.ts: discovers accounts + fetches positions from DataStore
-  |     - pythLazerOracle.ts: WebSocket price cache (4-connection pool, 200ms updates)
-  |     - store.ts: PostgreSQL via Prisma (PositionSnapshot, LiquidationCandidate, etc.)
-  |     - candleCollector.ts: OHLC candles from Hermes
-  |     - httpServer.ts: REST API at /health, /positions, /candidates, /executions
-  |     - ORACLE_MODE env var (default: "hermes") -- must be set to "lazer" for prod
-  |     - SCAN_INTERVAL_SECONDS: 30 (default)
-  |
-  +-- order-execution-keeper (port 37018)    <-- UNCHANGED for v1.7
-        - oracle.ts: Pyth Lazer WebSocket (single connection, 200ms updates)
-        - watcher.ts: EventEmitter WebSocket watching DepositCreated/WithdrawalCreated/OrderCreated
-        - poller.ts: DataStore polling every 5s (safety net)
-        - executor.ts: sequential queue, calls DepositHandler/WithdrawalHandler/OrderHandler
-        - KNOWN BUG: OrderHandler division-by-zero on JPY/USD reversed markets (triggerPrice=0)
+Pyth Hermes HTTP API
+       |
+       | HTTP poll every 2s (candleCollector.ts)
+       | HTTP poll per-request (pricesController.ts getTickers)
+       v
+keeper-service (Express, port 37017)
+  - candleCollector: polls Hermes, builds 1-min OHLC in memory, flushes to PostgreSQL
+  - pricesController: polls Hermes on each /prices/tickers request (no caching)
+  - candlesController: reads from DB + merges in-memory currentCandles
+       |
+       | HTTP poll every 1s (useTokenRecentPricesData via SWR)
+       | HTTP poll every 1s (DataFeed subscribeBars via PauseableInterval)
+       v
+Frontend (React/Vite on Vercel)
+  - useTokenRecentPricesData: fetches /prices/tickers, drives all price displays
+  - DataFeed.ts: fetches /prices/candles, drives TradingView chart
 ```
 
-## v1.7 Changes: What Changes vs What Stays the Same
+**Key problem:** Every frontend tab polls keeper every 1s for tickers AND every 1s for candles. Keeper itself re-fetches Hermes on every tickers request. With N tabs open, keeper makes N+30 HTTP requests/minute to Hermes just for tickers.
 
-### What Changes
+## Recommended Architecture (After WebSocket)
 
-**1. OrderHandler.sol — Contract Redeployment**
-
-The bug: when a user places a market order on a reversed market (JPY/USD), the frontend sets `triggerPrice=0`. `BaseOrderUtils.getExecutionPriceForIncrease()` computes `sizeDeltaUsd / sizeDeltaInTokens` where `sizeDeltaInTokens=0` for reversed markets, causing a Solidity panic (division by zero). This only affects reversed markets (currently JPY/USD).
-
-The fix: add a guard in `BaseOrderUtils.sol` before the division: if `sizeDeltaInTokens == 0`, return `acceptablePrice` directly (matching the fallback behavior already documented in the code comments). Redeploy `OrderHandler.sol` only — `LiquidationHandler.sol` is not affected.
-
-**Impact of redeployment:** Every service that holds `ORDER_HANDLER_ADDRESS` must be updated. The `LiquidationHandler.executeLiquidation()` does NOT use `OrderHandler` — it creates the order internally via `LiquidationUtils.createLiquidationOrder()` and executes it through `BaseOrderHandler._getExecuteOrderParams()`. So the liquidation pipeline is unaffected by the OrderHandler redeploy.
-
-**2. keeper-service — Liquidation Pipeline Fixes**
-
-The liquidation pipeline exists but has not been verified end-to-end on Base Sepolia. Issues to address:
-
-- `ORACLE_MODE` must be `"lazer"` for the scanner's `getTokenPrice()` to use `PythLazerFeedProvider.getStoredPrice()`. In Hermes mode, `pythLazerOracle` singleton is null and `executor.ts` line 71 (`lazerOracle?.getLatestUpdate(token)`) silently passes `"0x"` as oracle data, relying on stored prices. This works only if the order-execution-keeper has recently pushed prices on-chain.
-- The scanner's `discoverAccountsWithPositions()` calls `getBytes32ValuesAt` in a loop with serial RPC calls — N positions = N RPC calls. This is the primary scanning bottleneck at scale.
-- The executor calls `positionFetcher.fetchAccountPositions()` again during execution (step 4) to get `collateralToken` and `isLong` — this is a redundant RPC call since the scanner already fetched this data in `processPosition()`.
-- The `riskEngine.ts` is imported but never called in `scanner.ts`. The scanner calls `Reader.isPositionLiquidatable()` directly instead. `riskEngine.ts` is dead code.
-- The `confirmator.ts` watches `EventLog2` via HTTP long-polling (not WebSocket), which may miss events if the RPC connection drops.
-
-**3. docker-compose.yml — Environment Variables**
-
-After OrderHandler redeployment, `ORDER_HANDLER_ADDRESS` must be updated in `docker-compose.yml`. Additionally, `keeper-service` needs `ORACLE_MODE=lazer` if it is not already set.
-
-### What Stays the Same
-
-| Component | Status | Notes |
-|-----------|--------|-------|
-| postgres container | Unchanged | Schema, volumes, both databases retained |
-| order-execution-keeper (37018) | Unchanged | Redeploy OrderHandler address only |
-| LiquidationHandler contract | Unchanged | Not involved in the bug |
-| DataStore / Reader / EventEmitter | Unchanged | Core infrastructure contracts unchanged |
-| PythLazerFeedProvider | Unchanged | Stores on-chain prices, used by liquidation executor |
-| keeper-service DB schema (Prisma) | Unchanged | PositionSnapshot, LiquidationCandidate models stay |
-| keeper-service httpServer | Unchanged | /health, /candidates, /executions endpoints stay |
-| candleCollector | Unchanged | Not related to liquidation |
-| BetterStack monitoring | Unchanged | Pings /health at both ports |
-| Vercel frontend | Unchanged | No UI changes for liquidation keeper |
+```
+Pyth Hermes SSE Stream
+  /v2/updates/price/stream?ids[]=...
+       |
+       | Single persistent SSE connection (EventSource)
+       v
+keeper-service (Express + ws, port 37017)
+  +-- priceStreamCollector.ts (NEW - replaces both candleCollector polling AND pricesController polling)
+  |     - Connects to Hermes SSE
+  |     - Maintains latestTickers Map<symbol, TickerData> (in-memory)
+  |     - Maintains currentCandles Map<symbol, InMemoryCandle> (replaces candleCollector)
+  |     - Flushes completed candles to PostgreSQL (same as today)
+  |
+  +-- wsServer.ts (NEW - WebSocket server on same HTTP server)
+  |     - Upgrades /ws/prices to WebSocket
+  |     - Broadcasts ticker updates to all connected clients
+  |     - Broadcasts candle updates to subscribed clients
+  |     - Tracks client subscriptions (which symbols, which resolutions)
+  |
+  +-- pricesController.ts (MODIFIED - reads from in-memory cache, no more Hermes calls)
+  +-- candlesController.ts (UNCHANGED - still serves historical candles from DB)
+       |
+       | WebSocket (persistent connection per tab)
+       v
+Frontend (React/Vite on Vercel)
+  +-- usePriceWebSocket.ts (NEW - single WS connection per tab)
+  |     - Connects to keeper ws://keeper/ws/prices
+  |     - Dispatches ticker updates to global price store
+  |     - Dispatches candle updates to TradingView subscribers
+  |
+  +-- useTokenRecentPricesData.ts (MODIFIED - reads from WS store, HTTP fallback)
+  +-- DataFeed.ts (MODIFIED - subscribeBars uses WS push, HTTP fallback)
+```
 
 ## Component Boundaries
 
 | Component | Responsibility | Communicates With |
 |-----------|---------------|-------------------|
-| **scanner.ts** | Discover accounts with positions, call `Reader.isPositionLiquidatable()`, create DB candidate records | positionFetcher, PythLazerFeedProvider (stored prices), Reader contract, store.ts |
-| **positionFetcher.ts** | Fetch all positions from DataStore POSITION_LIST or per-account | DataStore contract, Reader contract |
-| **executor.ts** (liq) | Build oracle params, call `LiquidationHandler.executeLiquidation()`, record execution in DB | LiquidationHandler contract, PythLazerFeedProvider, Reader, store.ts |
-| **confirmator.ts** | Watch EventLog2 for OrderExecuted events, update DB status | EventEmitter contract (HTTP polling), store.ts, Reader contract |
-| **pythLazerOracle.ts** | Maintain 200ms price cache from Pyth Lazer WS | Pyth Lazer WS, PythLazerFeedProvider contract (push prices on-chain) |
-| **order-execution-keeper oracle.ts** | Maintain price cache, push prices every 5s via background interval | Pyth Lazer WS, PythLazerFeedProvider contract |
-| **LiquidationHandler.sol** | Create liquidation order on-chain, validate oracle prices, execute position decrease | Oracle contract (via withOraclePrices modifier), DataStore, EventEmitter |
+| **priceStreamCollector** (keeper, NEW) | Single SSE connection to Pyth Hermes. Parses price updates, maintains in-memory ticker cache + candle state. Flushes completed candles to DB. Emits events for wsServer. | Pyth Hermes SSE, PostgreSQL, wsServer (EventEmitter) |
+| **wsServer** (keeper, NEW) | WebSocket server mounted on Express HTTP server. Manages client connections, subscriptions, heartbeats. Broadcasts price/candle events from priceStreamCollector. | priceStreamCollector (listens to events), frontend WS clients |
+| **pricesController** (keeper, MODIFIED) | HTTP GET /prices/tickers still works but reads from priceStreamCollector's in-memory cache instead of calling Hermes. Zero-latency responses. | priceStreamCollector (reads cache) |
+| **candlesController** (keeper, UNCHANGED) | HTTP GET /prices/candles still reads from DB + in-memory currentCandles. No changes needed. | PostgreSQL, priceStreamCollector (reads currentCandles) |
+| **usePriceWebSocket** (frontend, NEW) | React hook managing a single WS connection. Reconnects on disconnect. Pushes updates into a shared price store (Zustand or context). | keeper wsServer, frontend price store |
+| **useTokenRecentPricesData** (frontend, MODIFIED) | Reads from WS-fed price store instead of polling. Falls back to HTTP if WS disconnected. | usePriceWebSocket (reads store), keeper HTTP (fallback) |
+| **DataFeed.subscribeBars** (frontend, MODIFIED) | Receives candle pushes via WS callback instead of PauseableInterval polling. Falls back to HTTP polling if WS disconnected. | usePriceWebSocket (registers candle subscription), keeper HTTP (fallback) |
 
-## Oracle Price Flow
+## Data Flow
 
-The liquidation pipeline has a critical dependency on on-chain stored prices:
-
-```
-Pyth Lazer WebSocket (200ms)
-  |
-  +-> order-execution-keeper oracle.ts cache (in-memory)
-  |     - Pushes to PythLazerFeedProvider on-chain every ~5s
-  |     - Also sends inline price data on every executeDeposit/Withdrawal/Order call
-  |
-  +-> keeper-service pythLazerOracle.ts cache (in-memory, 4-connection pool)
-        - Provides rawUpdate bytes for inline oracle params in executeLiquidation
-        - Falls back to "0x" if no cached update (relies on order-execution-keeper's push)
-
-keeper-service scanner.ts getTokenPrice():
-  -> reads PythLazerFeedProvider.getStoredPrice(tokenAddress) on-chain
-  -> validates age < 60 seconds
-  -> uses stored price for isPositionLiquidatable() check
-  -> NOTE: this means liquidatability is assessed against on-chain stored prices,
-     which are ~5s stale (last push from order-execution-keeper)
-
-keeper-service executor.ts buildOracleParams():
-  -> tries pythLazerOracle.getLatestUpdate(token) for inline price bytes
-  -> if null: falls back to "0x" (relies on stored price in PythLazerFeedProvider)
-  -> LiquidationHandler.withOraclePrices reads the stored price when data is "0x"
-```
-
-**Key insight:** The liquidation keeper does NOT need its own on-chain price push mechanism — it piggybacks on the order-execution-keeper's 5s background push. The 60s staleness check in `getTokenPrice()` provides the safety margin.
-
-## Contract Redeployment Steps
-
-When OrderHandler is redeployed, the following config locations must be updated:
-
-| Service | File | Field |
-|---------|------|-------|
-| order-execution-keeper | `docker-compose.yml` | `ORDER_HANDLER_ADDRESS` |
-| order-execution-keeper | `.env` (server) | `ORDER_HANDLER_ADDRESS` |
-| Interface SDK | `sdk/src/configs/contracts.ts` | orderHandler |
-| Interface | `src/config/static/markets.ts` | (may reference handler) |
-| Interface | `src/config/multichain.ts` | (may reference handler) |
-| Contracts repo | `0xmarkets_contract/config/` | OrderHandler address |
-
-LiquidationHandler does NOT need updating — it is not redeployed.
-
-### Redeployment Verification
-
-After redeployment, verify:
-1. E2E test for JPY market order completes without revert (was the 1 skipped test)
-2. `Data.OrderHandler` in DataStore matches new address (on-chain audit)
-3. keeper-service and order-execution-keeper restart cleanly with new address
-
-## Liquidation Pipeline Data Flow
+### Ticker Price Flow (new)
 
 ```
-Every 30 seconds (SCAN_INTERVAL_SECONDS):
-  |
-  scanner.scan()
-    |
-    1. positionFetcher.discoverAccountsWithPositions()
-       -> DataStore.getBytes32Count(POSITION_LIST_KEY)
-       -> DataStore.getBytes32ValuesAt(POSITION_LIST_KEY, 0, N)  [one call]
-       -> for each key: Reader.getPosition(dataStore, key)        [N serial calls -- BOTTLENECK]
-       -> extract unique accounts
-    |
-    2. for each account: positionFetcher.fetchAccountPositions(account)
-       -> Reader.getAccountPositions(dataStore, account, 0, 100)
-    |
-    3. for each position with sizeInUsd > 0:
-       a. Reader.getMarket(dataStore, market)
-       b. PythLazerFeedProvider.getStoredPrice(indexToken)  [3 calls: index, long, short]
-       c. Reader.isPositionLiquidatable(dataStore, referralStorage, positionKey, market, prices, true)
-       |
-       If liquidatable:
-         d. store.savePositionSnapshot()         [DB write]
-         e. store.createCandidate()               [DB write]
-         f. walletClient.signMessage()            [local crypto]
-         g. store.saveSignedDecision()            [DB write]
-         h. executor.execute()
-            |
-            4. store.getPositionSnapshotById()   [DB read]
-            5. positionFetcher.fetchAccountPositions()  [REDUNDANT -- already done in step 2]
-            6. Reader.getMarket(dataStore, market)      [REDUNDANT -- done in step 3a]
-            7. buildOracleParams()
-               -> pythLazerOracle.getLatestUpdate(token) for each token
-            8. publicClient.estimateFeesPerGas()
-            9. publicClient.estimateContractGas()
-            10. walletClient.writeContract(LiquidationHandler.executeLiquidation)
-            11. store.createExecution()          [DB write]
-            12. store.updateCandidateStatus()    [DB write]
-    |
-  confirmator (background EventLog2 watcher):
-    - on OrderExecuted: store.updateExecutionStatus(MINED)
-    - on candidateId: store.updateCandidateStatus(EXECUTED)
+1. Hermes SSE emits price update (parsed JSON with price, conf, expo, publish_time)
+2. priceStreamCollector receives event:
+   a. Updates latestTickers[symbol] with normalized GMX-format price
+   b. Updates currentCandles[symbol] OHLC
+   c. Emits "ticker" event with {symbol, minPrice, maxPrice, ...}
+3. wsServer receives "ticker" event:
+   a. JSON-serializes: {"type":"ticker","data":[...tickers]}
+   b. Broadcasts to all connected WS clients
+4. Frontend usePriceWebSocket receives message:
+   a. Parses JSON
+   b. Updates global price store
+5. useTokenRecentPricesData reads from store (reactive, no polling)
 ```
 
-## Bottleneck Analysis
+### Candle Bar Flow (new)
 
-### Scanning Bottleneck: Serial RPC Calls
+```
+1. priceStreamCollector detects minute boundary crossed:
+   a. Flushes completed candle to PostgreSQL
+   b. Starts new candle
+   c. Emits "candle" event with {symbol, time, open, high, low, close}
+2. wsServer receives "candle" event:
+   a. Broadcasts to clients subscribed to that symbol
+3. Frontend DataFeed.subscribeBars callback fires:
+   a. Calls onTick() with the new bar
+   b. TradingView chart updates in real-time
+```
 
-`discoverAccountsWithPositions()` makes N+1 serial RPC calls for N positions:
-- 1 call: `getBytes32Count`
-- N calls: `Reader.getPosition` (one per position key, in a for loop)
+### In-Progress Candle Updates (critical for chart liveness)
 
-For 100 positions, this is 101 serial RPC calls. Base Sepolia latency ~100-200ms per call = 10-20 seconds per scan cycle. This exceeds the 30s scan interval once position count grows.
+```
+1. priceStreamCollector updates currentCandles[symbol].close on every SSE tick
+2. Every 200ms (batched), wsServer broadcasts current candle state:
+   {"type":"candle_update","data":{"symbol":"WETH","time":1709654400,"open":3100,"high":3105,"low":3098,"close":3102}}
+3. Frontend DataFeed.subscribeBars receives update:
+   a. Calls onTick() with updated bar (same time = update existing bar)
+   b. TradingView chart shows live price movement within current candle
+```
 
-**Fix:** Use `publicClient.multicall()` to batch all `Reader.getPosition` calls into a single RPC request. This reduces 100 serial calls to 1 multicall.
+This is the key difference from only broadcasting on minute boundaries. Without in-progress updates, the chart would freeze for 60 seconds between candle completions.
 
-### Execution Bottleneck: Redundant Fetches
+### WebSocket Protocol
 
-`executor.execute()` re-fetches position data from the contract (step 5) even though `scanner.processPosition()` already has the `collateralToken` and `isLong` from step 2. The data should be passed through from the scanner to avoid the extra fetch.
+```typescript
+// Client -> Server (subscription)
+{ "type": "subscribe", "channel": "tickers" }
+{ "type": "subscribe", "channel": "candles", "symbol": "WETH", "resolution": "1" }
+{ "type": "unsubscribe", "channel": "candles", "symbol": "WETH" }
 
-**Fix:** Pass `collateralToken` and `isLong` directly from `PositionSnapshot` (they are already stored in the struct as optional fields). Eliminate the `fetchAccountPositions()` call in executor.
+// Server -> Client (data)
+{ "type": "ticker", "data": [{ symbol, minPrice, maxPrice, tokenAddress, updatedAt }] }
+{ "type": "candle", "data": { symbol, time, open, high, low, close } }
+{ "type": "candle_update", "data": { symbol, time, open, high, low, close } }
+{ "type": "ping" }
 
-### RiskEngine: Dead Code
+// Client -> Server (keepalive)
+{ "type": "pong" }
+```
 
-`riskEngine.ts` defines `checkLiquidation()` but it is never called. The scanner uses `Reader.isPositionLiquidatable()` instead, which is the correct approach (authoritative on-chain check). The `riskEngine.ts` module uses a simplified off-chain calculation that could diverge from contract math.
+## Patterns to Follow
 
-**Decision:** Remove `riskEngine.ts` or document it as dead code. The on-chain `isPositionLiquidatable()` is the authoritative source.
+### Pattern 1: Single Source of Truth for Prices
 
-### Oracle Mode: Config Risk
+**What:** priceStreamCollector owns ALL price data. Both WS broadcasts and HTTP endpoints read from the same in-memory cache.
 
-`keeper-service/src/config.ts` defaults `oracleMode` to `"hermes"`. In Hermes mode, the scanner's executor still works (it reads stored prices) but the `pythLazerOracle` singleton is null, so `buildOracleParams()` passes `"0x"` for all inline price data. This works only because the order-execution-keeper keeps stored prices fresh. If the order-execution-keeper is down, liquidation executions will fail with stale oracle errors.
+**Why:** Eliminates divergence between WS prices and HTTP prices. A client reconnecting via HTTP sees the same data as WS-connected clients.
 
-**Recommendation:** Set `ORACLE_MODE=lazer` in docker-compose.yml for keeper-service so it maintains its own Lazer WebSocket and can provide inline price bytes independently.
+```typescript
+// priceStreamCollector.ts
+export const latestTickers = new Map<string, TickerData>();
+export const currentCandles = new Map<string, InMemoryCandle>();
 
-## Build Order for v1.7
+// pricesController.ts (modified)
+export const getTickers = (_req: Request, res: Response) => {
+  const tickers = Array.from(latestTickers.values());
+  if (tickers.length === 0) {
+    return res.status(503).json({ error: "No price data available" });
+  }
+  res.json(tickers);
+};
+```
 
-### Step 1: Contract Bug Fix (independent, unblocked)
-Fix `BaseOrderUtils.sol`, redeploy `OrderHandler.sol`, record new address.
-- No other steps depend on this completing first.
-- Can be done in parallel with Step 2.
+### Pattern 2: WS with HTTP Fallback
 
-### Step 2: Config Updates (depends on Step 1 completing)
-Update `ORDER_HANDLER_ADDRESS` everywhere (docker-compose.yml, .env, SDK configs).
-- Requires the new address from Step 1.
-- Run address audit to verify consistency across all services.
+**What:** Frontend tries WS first but falls back to HTTP polling if WS connection fails or is unavailable (e.g., behind certain proxies).
 
-### Step 3: Liquidation Verification (depends on keeper-service being accessible)
-Confirm the existing pipeline works against a real liquidatable position:
-- Create a test position near liquidation threshold
-- Watch scanner logs for candidate detection
-- Watch executor logs for `LiquidationHandler.executeLiquidation` call
-- Verify confirmator updates status to EXECUTED
-- Set `ORACLE_MODE=lazer` before testing if not already set.
+**Why:** WebSocket upgrades can fail behind corporate proxies, load balancers, or Cloudflare. HTTP polling must remain functional.
 
-### Step 4: Performance Optimization (depends on Step 3 verification)
-Only optimize after verifying the pipeline works. Premature optimization hides bugs.
-- Batch `getPosition` calls in `discoverAccountsWithPositions()` using multicall
-- Eliminate redundant `fetchAccountPositions()` in executor
-- Consider removing/archiving dead `riskEngine.ts`
+```typescript
+// usePriceWebSocket.ts
+function usePriceWebSocket(keeperUrl: string) {
+  const [connected, setConnected] = useState(false);
+  // ... WS connection logic
+  return { connected, prices };
+}
 
-### Step 5: Deploy and Verify
-Redeploy keeper-service with optimizations, run E2E scan under load.
+// useTokenRecentPricesData.ts (modified)
+const { connected, prices: wsPrices } = usePriceWebSocket(keeperUrl);
+// If WS connected, use wsPrices. Otherwise fall back to SWR polling.
+```
 
-## New vs Modified Components
+### Pattern 3: Mount WS on Existing HTTP Server
 
-### New: None
+**What:** Use the `ws` npm package and attach to the existing Express HTTP server returned by `app.listen()`.
 
-No new files are required. All changes are modifications to existing files.
+**Why:** No new port needed. Shares the existing CORS and routing infrastructure. The `/ws/prices` path is handled by the upgrade event, not Express routes.
 
-### Modified
+```typescript
+// wsServer.ts
+import { WebSocketServer } from 'ws';
 
-| Component | File | Change |
-|-----------|------|--------|
-| Contract | `0xmarkets_contract/contracts/order/BaseOrderUtils.sol` or via OrderHandler deploy | Add `sizeDeltaInTokens == 0` guard |
-| Config (all services) | `docker-compose.yml`, `.env`, SDK configs | New `ORDER_HANDLER_ADDRESS` |
-| scanner.ts | `keeper-service/src/core/scanner.ts` | Replace serial getPosition loop with multicall batch |
-| executor.ts (liq) | `keeper-service/src/core/executor.ts` | Remove redundant fetchAccountPositions call, read from PositionSnapshot |
-| config (keeper-service) | `docker-compose.yml` | Add/set `ORACLE_MODE=lazer` for keeper-service |
+export function attachWebSocketServer(server: http.Server) {
+  const wss = new WebSocketServer({ noServer: true });
 
-### Deleted (Recommended)
+  server.on('upgrade', (request, socket, head) => {
+    if (request.url === '/ws/prices') {
+      wss.handleUpgrade(request, socket, head, (ws) => {
+        wss.emit('connection', ws, request);
+      });
+    } else {
+      socket.destroy();
+    }
+  });
 
-| Component | File | Why |
-|-----------|------|-----|
-| RiskEngine | `keeper-service/src/core/riskEngine.ts` | Dead code — scanner uses on-chain isPositionLiquidatable() instead |
+  return wss;
+}
+```
+
+### Pattern 4: Batched Broadcasts
+
+**What:** Don't broadcast every single SSE event individually. Batch ticker updates over a small window (100-200ms) and send one combined message.
+
+**Why:** Hermes SSE can fire very rapidly. Sending one message per SSE event wastes bandwidth and causes unnecessary React re-renders. Batching at 200ms gives 5 updates/second, plenty for a trading UI.
+
+### Pattern 5: Heartbeat/Ping-Pong
+
+**What:** Server sends `{"type":"ping"}` every 30s. Client responds with `{"type":"pong"}`. Server closes connections that miss 2 pings.
+
+**Why:** Detects dead connections that TCP keepalive misses (especially through proxies). Prevents resource leaks from abandoned tabs.
 
 ## Anti-Patterns to Avoid
 
-### Anti-Pattern 1: Skipping Verification Before Optimization
-**What:** Jumping straight to multicall optimization without first verifying the basic pipeline works.
-**Why bad:** Optimization changes can mask bugs. If the pipeline doesn't work before optimization, you don't know if a new failure is from the optimization or the underlying issue.
-**Instead:** Run a real liquidation end-to-end with the unmodified scanner first. Confirm the tx succeeds. Then optimize.
+### Anti-Pattern 1: Separate WS Port
 
-### Anti-Pattern 2: Updating OrderHandler Without Auditing All Services
-**What:** Updating only docker-compose.yml with the new OrderHandler address.
-**Why bad:** The Interface SDK, multichain config, and contracts repo all contain addresses. Partial updates cause execution failures for users while the keeper continues working (different code paths for each).
-**Instead:** Run the same contract address audit protocol used in v1.6 (Phase 20). Check DataStore on-chain to confirm the address the keeper uses matches what the SDK resolves.
+**What:** Running the WebSocket server on a different port (e.g., 37019).
 
-### Anti-Pattern 3: Replacing On-Chain Liquidatability Check with Off-Chain Math
-**What:** Using riskEngine.ts for liquidation decisions instead of Reader.isPositionLiquidatable().
-**Why bad:** The off-chain math in riskEngine.ts uses simplified collateral valuation (`collateralUsd = collateralAmount` without price conversion) and a generic MMR check. The on-chain check accounts for funding fees, borrowing fees, price impact, and market-specific parameters. Using the off-chain check would cause false negatives (missing real liquidations) and false positives (attempting to liquidate healthy positions, which reverts).
-**Instead:** Keep Reader.isPositionLiquidatable() as the sole liquidation decision gate.
+**Why bad:** Requires new firewall rules on DigitalOcean, new Vercel proxy config, CORS complications. The existing `/api/keeper` proxy on Vercel would not forward to a second port.
 
-### Anti-Pattern 4: Running scanner With ORACLE_MODE=hermes
-**What:** Leaving `ORACLE_MODE` at the default `"hermes"` value for keeper-service.
-**Why bad:** The pythLazerOracle singleton is null in Hermes mode. executor.ts line 71 silently passes "0x" for oracle data. This works when the order-execution-keeper is running and keeping prices fresh on-chain. If the order-execution-keeper restarts or falls behind, liquidation executions will revert with oracle staleness errors — with no warning in logs.
-**Instead:** Set `ORACLE_MODE=lazer` so keeper-service maintains its own Lazer WebSocket and can provide inline price bytes independently. This makes liquidation execution independent of the order-execution-keeper's price push cadence.
+**Instead:** Mount on the same Express HTTP server at `/ws/prices`.
 
-## Rollback Plan
+### Anti-Pattern 2: Broadcasting Raw Hermes Data
 
-If OrderHandler redeployment breaks something:
-- The old `ORDER_HANDLER_ADDRESS` is in git history for all config files
-- Roll back docker-compose.yml, restart order-execution-keeper
-- LiquidationHandler is NOT redeployed, so the liquidation keeper is unaffected
+**What:** Forwarding Pyth Hermes SSE events directly to frontend clients.
 
-If keeper-service optimizations cause regressions:
-- scanner.ts and executor.ts changes are isolated to the keeper-service container
-- Roll back keeper-service git commits, rebuild Docker container: `docker compose build keeper-service && docker compose up -d keeper-service`
-- No database migrations involved — the schema is unchanged
+**Why bad:** Frontend needs GMX-format prices (30-decimal precision, adjusted by token decimals). Raw Hermes data requires normalization. Also leaks Pyth feed IDs that mean nothing to the frontend.
+
+**Instead:** Normalize in priceStreamCollector, broadcast in the same TickerResponse format the HTTP endpoint already uses.
+
+### Anti-Pattern 3: Per-Client Hermes Connections
+
+**What:** Each WS client triggering its own Hermes subscription.
+
+**Why bad:** N clients = N SSE connections to Hermes. Wastes resources, may hit rate limits.
+
+**Instead:** Single SSE connection in priceStreamCollector, fan-out via wsServer.
+
+### Anti-Pattern 4: Removing HTTP Endpoints
+
+**What:** Deleting /prices/tickers and /prices/candles after adding WS.
+
+**Why bad:** External tools, health checks, debugging, and the fallback path all depend on HTTP. Other services (data-verification-service) may also consume these endpoints.
+
+**Instead:** Keep HTTP endpoints, just change their data source from "call Hermes" to "read in-memory cache".
+
+### Anti-Pattern 5: Frontend Direct-to-Hermes SSE
+
+**What:** Having the frontend connect directly to Pyth Hermes SSE, bypassing the keeper.
+
+**Why bad:** Each browser tab opens its own Hermes SSE connection (wastes resources). The frontend would need to duplicate the GMX price normalization logic that already exists in the keeper. Cannot share candle state across tabs.
+
+**Instead:** Keeper is the single Hermes consumer, frontend connects only to keeper.
+
+## Vercel Proxy Consideration
+
+The frontend connects to the keeper via Vercel's proxy rewrite (`/api/keeper` -> `http://142.93.203.222:37017`). WebSocket upgrade requests through Vercel require verifying that Vercel supports the `Upgrade: websocket` header forwarding.
+
+**Likely scenario (Vercel does NOT proxy WebSocket upgrades):** The frontend must connect directly to `wss://142.93.203.222:37017/ws/prices` (or a domain pointing to the DO droplet with TLS termination). This requires:
+- Adding a domain (e.g., `keeper.0xmarkets.io`) pointing to the DO droplet
+- TLS certificate (Let's Encrypt via Caddy or nginx reverse proxy)
+- The `getOracleKeeperUrl` config returns the HTTP URL; derive WS URL by replacing protocol
+
+**Alternative (if Vercel does proxy WS):** The frontend connects to `wss://app.0xmarkets.io/api/keeper/ws/prices`. Preferred if available, but less likely.
+
+Either way, the WS URL can be derived from the existing keeper URL by replacing `http(s)` with `ws(s)`.
+
+## Suggested Build Order
+
+Build order follows data flow: upstream source first, then server, then client.
+
+### Phase 1: Keeper - Hermes SSE + In-Memory Cache
+
+**Build:** priceStreamCollector.ts that connects to Pyth Hermes SSE `/v2/updates/price/stream`, maintains latestTickers and currentCandles in memory.
+
+**Modify:** pricesController.ts getTickers to read from latestTickers cache instead of calling Hermes. candleCollector.ts replaced by priceStreamCollector (same candle logic, different data source).
+
+**Verify:** HTTP /prices/tickers now reads from cache (zero Hermes calls per request). Candles still flush to DB. All existing HTTP endpoints work unchanged. Frontend works identically (still polling HTTP, just faster responses).
+
+**Dependencies:** None. This is a pure backend refactor. The frontend does not change.
+
+**Why first:** Everything downstream depends on having a streaming price source. Without this, there is nothing to broadcast via WS. Also independently valuable -- eliminates per-request Hermes polling even without WS.
+
+### Phase 2: Keeper - WebSocket Server
+
+**Build:** wsServer.ts mounted on existing HTTP server. Broadcasts ticker updates from priceStreamCollector events. Supports subscribe/unsubscribe for candle channels. Implements heartbeat.
+
+**Verify:** Can connect with `wscat -c ws://localhost:37017/ws/prices` and receive ticker broadcasts. Subscribe to candle channel and receive updates.
+
+**Dependencies:** Phase 1 (needs priceStreamCollector events to broadcast).
+
+**Why second:** Server must be broadcasting before clients can consume.
+
+### Phase 3: Frontend - WebSocket Client + Price Store
+
+**Build:** usePriceWebSocket hook with connection management, reconnection, store updates. Modify useTokenRecentPricesData to read from WS store with HTTP fallback. Modify DataFeed.subscribeBars to use WS push with polling fallback.
+
+**Verify:** Open trade page, prices update in real-time via WS. TradingView chart receives live bars without staleness. Disconnect WS (kill keeper), verify HTTP fallback kicks in within seconds. Reconnect, verify WS resumes.
+
+**Dependencies:** Phase 2 (needs keeper WS server running).
+
+**Why last:** Consumer of the data. Cannot test without server infrastructure.
+
+## Scalability Considerations
+
+| Concern | At 1-10 users (now) | At 100 users | At 1000+ users |
+|---------|---------------------|--------------|----------------|
+| Hermes connection | 1 SSE connection (persistent) | 1 SSE connection | 1 SSE connection |
+| WS connections | 1-10 connections, trivial | 100 connections, still trivial for `ws` | May need connection pooling or sticky sessions behind LB |
+| Broadcast cost | Negligible | ~100 JSON.stringify + send per tick | Consider binary protocol or shared buffer |
+| Memory | ~7 tickers + 7 candles in memory, negligible | Same | Same |
+| PostgreSQL writes | 7 candle upserts per minute (same as today) | Same | Same |
+
+Current scale (testnet, <10 users) means scalability is not a concern. The architecture naturally scales to hundreds of concurrent users without changes.
 
 ## Sources
 
-- Direct codebase analysis:
-  - `/Users/ken/Projects/0xM/keeper-service/src/core/scanner.ts` — full liquidation pipeline
-  - `/Users/ken/Projects/0xM/keeper-service/src/core/executor.ts` — liquidation execution
-  - `/Users/ken/Projects/0xM/keeper-service/src/core/positionFetcher.ts` — account discovery (bottleneck)
-  - `/Users/ken/Projects/0xM/keeper-service/src/core/riskEngine.ts` — dead code identified
-  - `/Users/ken/Projects/0xM/keeper-service/src/core/confirmator.ts` — event confirmation
-  - `/Users/ken/Projects/0xM/keeper-service/src/core/pythLazerOracle.ts` — oracle service
-  - `/Users/ken/Projects/0xM/keeper-service/src/index.ts` — startup, scan loop, ORACLE_MODE handling
-  - `/Users/ken/Projects/0xM/keeper-service/src/config.ts` — env var defaults
-  - `/Users/ken/Projects/0xM/order-execution-keeper-service/src/oracle.ts` — price push cadence
-  - `/Users/ken/Projects/0xM/order-execution-keeper-service/src/index.ts` — service startup
-  - `/Users/ken/Projects/0xM/docker-compose.yml` — deployment config
-  - `/Users/ken/Projects/0xM/0xmarkets_contract/contracts/exchange/LiquidationHandler.sol`
-  - `/Users/ken/Projects/0xM/0xmarkets_contract/contracts/liquidation/LiquidationUtils.sol`
-  - `/Users/ken/Projects/0xM/0xmarkets_contract/contracts/order/BaseOrderUtils.sol` — bug location
-  - `/Users/ken/Projects/0xM/0xmarkets_contract/contracts/order/DecreaseOrderUtils.sol`
-  - `/Users/ken/Projects/0xM/0xMarkets-Interface/.planning/PROJECT.md` — milestone context
-- Confidence: HIGH — all integration points verified from actual source code
+- Pyth Hermes SSE streaming: [Fetch Price Updates | Pyth Developer Hub](https://docs.pyth.network/price-feeds/core/fetch-price-updates)
+- Pyth Hermes architecture: [Hermes | Pyth Developer Hub](https://docs.pyth.network/price-feeds/core/how-pyth-works/hermes)
+- Existing codebase: keeper-service/src/core/candleCollector.ts, server/httpServer.ts, controllers/pricesController.ts, controllers/candlesController.ts
+- Frontend codebase: src/domain/tradingview/DataFeed.ts, src/domain/synthetics/tokens/useTokenRecentPricesData.ts, src/lib/oracleKeeperFetcher/oracleKeeperFetcher.ts

--- a/.planning/research/FEATURES.md
+++ b/.planning/research/FEATURES.md
@@ -1,173 +1,120 @@
-# Feature Landscape: Liquidation Keeper Verification and Performance (v1.7)
+# Feature Landscape: WebSocket Price Streaming
 
-**Domain:** GMX-style perpetual futures liquidation keeper — verification + optimization of existing pipeline
-**Researched:** 2026-02-27
-**Milestone:** v1.7 Liquidation Readiness
-**Overall confidence:** HIGH (based on direct source code analysis of keeper-service, contract code, and prior phase research)
+**Domain:** Real-time price streaming for perpetual futures trading interface
+**Researched:** 2026-03-05
+**Context:** Replacing HTTP polling (1s frontend, 2s keeper) with WebSocket streaming for v1.12
 
-## Context: What Already Exists
+## Current State
 
-The keeper-service already has a complete liquidation pipeline. This milestone is not about building it — it's about verifying it works, fixing known bugs, and optimizing the hot path.
+The system has three HTTP polling loops that add unnecessary latency:
 
-**Existing components (all in `keeper-service/src/core/`):**
-
-| Component | File | Current Status |
-|-----------|------|----------------|
-| Position scanner | `scanner.ts` | Auto-discovers via DataStore POSITION_LIST, calls `Reader.isPositionLiquidatable()`, creates LiquidationCandidate records |
-| Risk engine | `riskEngine.ts` | Local MMR-based check — currently bypassed in scan loop; scanner delegates to contract Reader instead |
-| Executor | `executor.ts` | Builds oracle params from Pyth Lazer cache, calls `LiquidationHandler.executeLiquidation()` |
-| Confirmator | `confirmator.ts` | Watches EventLog2 for OrderExecuted events, marks executions MINED |
-| Position fetcher | `positionFetcher.ts` | Paginates over `Reader.getAccountPositions()` and DataStore `getBytes32ValuesAt()` sequentially |
-| Oracle service | `pythLazerOracle.ts` | WebSocket cache of Lazer price updates at 200ms cadence; 7 tokens registered |
-| Audit store | `store.ts` | PostgreSQL audit trail of snapshots, candidates, signed decisions, executions |
-
-**Critical external dependency:** The scanner reads stored on-chain prices via `PythLazerFeedProvider.getStoredPrice()`. These prices are pushed by the order-execution-keeper's background Lazer updater (every 5s). This cross-service dependency must be verified before any liquidation execution test.
+| What | Current Approach | Latency Cost |
+|------|-----------------|--------------|
+| Keeper candle data | `candleCollector.ts` polls Pyth Hermes HTTP every 2s via `HermesClient.getLatestPriceUpdates()` | 0-2s stale per tick, misses intra-interval price extremes |
+| Frontend mark prices | `useTokenRecentPricesRequest` polls `/prices/tickers` every 1s via SWR through Vercel proxy | 0-1s stale + network RTT through Vercel -> DO keeper |
+| Frontend chart bars | `DataFeed.subscribeBars` polls `fetchCandles` every 1s via `PauseableInterval` | 0-1s stale + fetches full candle(s) each tick |
 
 ---
 
 ## Table Stakes
 
-Features that must work correctly. Missing = liquidation keeper is not functional for this milestone.
+Features users expect. Missing = product feels laggy or broken compared to competitors (Hyperliquid, dYdX).
 
-| Feature | Why Required | Complexity | Current State | Notes |
-|---------|--------------|------------|---------------|-------|
-| Contract role verification: `LIQUIDATION_KEEPER` role | `LiquidationHandler.executeLiquidation()` has `onlyLiquidationKeeper` modifier. If the keeper wallet doesn't have this role, every call reverts at the gate. | Low | Unknown — not verified yet | Must check RoleStore for keeper wallet address before any execution test |
-| Stored price freshness from order-execution-keeper | Scanner's `getTokenPrice()` reads `PythLazerFeedProvider.getStoredPrice()`. If the order-execution-keeper hasn't pushed a price in the last 60s, scanner skips the position. Executor's oracle params also rely on stored prices. | Medium | Architecture correct; cross-service dependency not live-verified | Verify end-to-end: order-execution-keeper running → stored prices present → keeper-service can read them |
-| `Reader.isPositionLiquidatable()` returning accurate results | The scanner calls this with constructed MarketPrices. It must return `true` for a genuinely underwater position. | Medium | Contract logic correct per code review; needs a live test position | Requires creating an underwater position on Base Sepolia to confirm the full detection path |
-| `executeLiquidation` not reverting | The full contract call must succeed. Depends on: correct oracle params, valid `(account, market, collateralToken, isLong)` tuple, and fresh prices. | Medium | Architecture correct per code review; not live-verified | |
-| Contract bug fix: reversed markets (JPY/USD) | Known `division-by-zero` in OrderHandler.sol when `triggerPrice=0` for reversed markets. Blocks testing JPY/USD liquidations and affects any reversed-market order. | Medium | Bug confirmed in PROJECT.md (Phase 24 reference) | Must guard `triggerPrice` before division in the contract; redeploy; update all service configs |
-| Candidate deduplication: no double-execution on same position | Once an `executeLiquidation` TX is submitted, the position is closed. A second TX on the same position key reverts (position doesn't exist). Without a guard, if the scan runs while a TX is in-flight, the position is submitted twice. | Low | `scanRunning` flag prevents overlapping scan cycles, but no in-flight deduplication across the scan-to-execute gap | A 30s scan interval with Flashblocks 200ms confirmations means the position is confirmed closed before the next scan. But a dedup guard is cheap insurance. |
+| Feature | Why Expected | Complexity | Notes |
+|---------|--------------|------------|-------|
+| Keeper: Pyth Hermes SSE for candle data | Hermes offers `/v2/updates/price/stream` SSE endpoint that pushes updates as they happen (~400ms). Current 2s polling misses price extremes between ticks and adds 0-2s latency. `HermesClient` already has `getStreamingPriceUpdates(priceIds)` built-in. | Low | Direct replacement of `setInterval(tick, 2000)` in `candleCollector.ts`. Single file change. Auto-reconnect needed (Hermes closes after 24h). |
+| Keeper: WebSocket endpoint for frontend | Frontend polls `/prices/tickers` every 1s. Each poll = full HTTP round-trip through Vercel serverless proxy -> DO keeper. WebSocket eliminates per-request overhead and gives sub-100ms push latency. | Medium | Needs `ws` package on keeper. Must broadcast ticker + candle updates to all connected frontends. Vercel serverless **cannot** hold WS connections, so frontend connects directly to keeper. |
+| Frontend: Mark prices via keeper WS | `useTokenRecentPricesRequest` uses SWR with 1s `refreshInterval` to poll tickers. Replace with WS subscription that updates React state on each push. All downstream consumers (positions, PnL, trade box, ~20 components) get instant updates. | Medium | Single integration point in price context. Must handle reconnection, stale detection, fallback to polling. |
+| Frontend: TradingView real-time bars via WS | `subscribeBars` uses `PauseableInterval` polling `fetchCandles` at 1s. Chart feels stale because it only updates on next poll completion. With WS, bars update on each price tick. | Medium | TradingView requirements: bar time = period start not update time, only update most recent bar or add newer, callbacks must be async. Current `subscribeBars` already has bar patching logic -- just swap data source from polling to WS push. |
+| Connection resilience: auto-reconnect with backoff | Every DeFi trading interface handles disconnects gracefully. Users on flaky connections or after sleep/wake must not see stale prices without knowing it. | Low | Exponential backoff with jitter. Existing `WebsocketContextProvider.tsx` already implements reconnect + health check patterns for the RPC WS provider -- same approach. |
+| Stale price indicator | If WS disconnects or prices stop arriving, user must know prices are stale. Trading on stale prices = real money lost. | Low | Timestamp of last update, show warning banner if >5s stale. `KeeperStatusBanner.tsx` already exists for keeper health -- extend it. |
 
 ## Differentiators
 
-Features that improve speed and operational confidence without being strictly required for correctness.
+Features that set the product apart. Not expected in testnet/early stage, but valuable.
 
-| Feature | Value Proposition | Complexity | Dependencies |
-|---------|-------------------|------------|--------------|
-| Per-stage timing instrumentation | `performance.now()` at: scan start, per-position liquidatability check, oracle param build, TX submit, TX confirmation. Matches pattern from order-execution-keeper (Phase 14). Identifies bottlenecks. | Low | Node.js built-in; pino already in use; no new dependencies |
-| Position-key deduplication guard in executor | Track recently submitted position keys (in-memory Map with ~60s TTL) to prevent submitting two TXs for the same position within one confirmation window. Defense against scanner running while TX is in-flight. | Low | New Map in executor; no DB change; complements existing `scanRunning` flag |
-| `REVERTED` status for failed executions | Confirmator currently only handles the success path. If a TX mines but reverts (e.g., position recovered between detection and execution), the execution stays in SUBMITTED status forever. Check `receipt.status` and update to REVERTED. | Low | `publicClient.getTransactionReceipt()` already called in confirmator; just check `.status` |
-| Batched multicall for position key discovery | Current `discoverAccountsWithPositions()` fetches each position key individually (N separate `getPosition()` calls inside a loop). With multicall enabled on publicClient, batch these into single round-trips. Materially faster with >50 open positions. | Medium | viem multicall already enabled in publicClient (`batch: { multicall: true }`); Reader ABI already imported; requires restructuring the per-key loop |
-| Configurable scan interval tuning | `SCAN_INTERVAL_SECONDS` is already config-driven (default 30s). Document recommended values: 30s for testnet, 5–15s for mainnet. For v1.7, verify the default is sufficient given 200ms Flashblocks confirmations. | Very Low | Already implemented; needs documentation and verification only |
-| Scan-cycle counters in health endpoint | Add `candidatesDetected`, `candidatesExecuted`, `candidatesFailed` counters to `/health` response. Current health tracks `lastScanAt` but not outcome counters. | Low | `healthState.ts` already exists; extend with a few new exported counters |
+| Feature | Value Proposition | Complexity | Notes |
+|---------|-------------------|------------|-------|
+| Sub-second PnL updates | Position PnL recalculated on every price tick instead of every 1s poll. Feels like a CEX. Hyperliquid does this and it is a big part of why traders prefer it. | Low | Once mark prices stream via WS, PnL is a derived calculation. Already computed reactively from `pricesData` in position components. Free win. |
+| More accurate candle high/low | Instead of building candles from 2s HTTP snapshots (missing intra-period price extremes), build from every Hermes SSE tick. Higher tick rate = more accurate high/low. | Low | Already doing candle aggregation in `candleCollector.ts`. SSE gives more data points, highs/lows become more accurate with zero extra work. |
+| Multi-resolution chart streaming | Stream candle updates at user's selected resolution without fetching full candle history on each subscribeBars tick. Currently fetches 1+ candles per second regardless of resolution. | Medium | Keeper builds candles at 1m granularity. Frontend aggregates to higher resolutions. WS pushes only current candle update, not full refetch. |
+| Ticker data broadcast on connect | Send latest ticker snapshot immediately on WS connection, so frontend has prices before first push arrives. Eliminates cold-start delay. | Low | Buffer latest ticker state in keeper memory, send on `connection` event. Avoids the "loading prices..." gap on page load. |
 
 ## Anti-Features
 
-Features to explicitly NOT build for this milestone.
+Features to explicitly NOT build.
 
 | Anti-Feature | Why Avoid | What to Do Instead |
 |--------------|-----------|-------------------|
-| Parallel scan execution | Running two scan cycles concurrently risks double-submission. The `scanRunning` flag exists for this reason. Parallel scanning does not improve throughput for single-wallet execution. | Keep sequential scan with `scanRunning` guard |
-| On-chain price pushes from keeper-service during liquidation | keeper-service and order-execution-keeper share the same keeper wallet. Pushing prices from keeper-service creates nonce conflicts. The existing design — read stored prices that order-execution-keeper pushes — is correct. | Rely on order-execution-keeper's 5s background price pushes; never call `updatePriceOnChain()` from keeper-service executor |
-| Local `riskEngine.ts` MMR check in the scan loop | `riskEngine.ts` duplicates what `Reader.isPositionLiquidatable()` already does on-chain with accurate parameters. Running both adds ~1 RPC round-trip per position for no benefit. The scanner correctly delegates to the contract. | Leave riskEngine unused; do not wire it into the scan loop |
-| Liquidation reward tracking | This contract does not pay liquidation bots. There is no keeper incentive to track or claim. | Omit entirely |
-| Building `previewLiquidation` flow | `PreviewResult` type exists in `types.ts` and `preview.ts` is a stub. The `Reader.isPositionLiquidatable()` call already answers "should we liquidate?" No preview flow is needed for the verification goal. | Use existing `isPositionLiquidatable` result; delete stub or leave as-is |
-| Multi-wallet executor | Multiple wallets require nonce coordination. Single wallet sequential model is correct for testnet. | One keeper wallet; optimize within that constraint |
-| Cross-chain liquidation support | Protocol is Base Sepolia only. | Ignore |
+| Order book WebSocket | 0xMarkets uses oracle-based pricing, not an order book. There is no order book to stream. Building a fake one is misleading. | Show mark price from oracle. That is the execution price. |
+| Per-user position streaming | Streaming individual user position changes via WS adds complexity for minimal gain. Position changes are infrequent (user-initiated trades). | Poll positions on trade events, use existing `SyntheticsEventsProvider` for execution notifications. |
+| WebSocket for candle history | Historical candles do not change. Streaming them wastes bandwidth. | REST for history (`getBars` stays HTTP), WS only for the current live bar (`subscribeBars` uses WS). |
+| Client-side candle aggregation from raw ticks | Having the browser aggregate raw Pyth ticks into candles is error-prone (tab sleep, missed ticks, clock skew). | Keeper aggregates candles server-side, streams completed/updated candles to frontend. Single source of truth. |
+| Multiple WS connections per client | One for tickers, one for candles, one for events -- connection overhead adds up, especially on mobile. | Single multiplexed WS connection with message types: `{ type: "ticker", data: ... }`, `{ type: "candle", data: ... }`. |
+| Pyth Lazer for price display | Lazer is for oracle signing (on-chain execution). It requires a Pro API key and has different semantics than Hermes. | Use Hermes SSE for display prices (keeper side). Lazer stays for oracle signing only. |
+| Direct browser-to-Hermes SSE | Skip keeper for mark prices. Browser connects to Pyth Hermes directly. | Bad: exposes Pro API key client-side, CORS issues on public endpoint, rate limits. Keep keeper as price aggregator. |
+| Binary/protobuf encoding | Compact binary frames instead of JSON for WS messages. | Premature optimization. 7 tokens x JSON ticker is ~2KB. Not a bottleneck for 6 markets on testnet. |
 
 ## Feature Dependencies
 
 ```
-Phase A: Contract Fix (prerequisite for reversed-market tests)
-  OrderHandler.sol triggerPrice=0 guard
-    -> redeploy contracts
-    -> update all service configs (keeper-service, order-execution-keeper, squid, docs)
-    -> unlocks JPY/USD liquidation testing
+Keeper Hermes SSE ───────────────────> Keeper WS endpoint
+  (replaces 2s HTTP poll                (serves frontends)
+   in candleCollector.ts)                    |
+                                             |
+                          +------------------+------------------+
+                          |                                     |
+                          v                                     v
+              Frontend mark prices via WS          TradingView real-time bars via WS
+              (replaces 1s SWR poll in             (replaces 1s PauseableInterval
+               useTokenRecentPricesData)            poll in DataFeed.subscribeBars)
+                          |                                     |
+                          v                                     v
+              Sub-second PnL updates               Multi-resolution streaming
+              (derived from mark prices)           (enhancement, deferred)
 
-Phase B: Verification (prove existing pipeline works)
-  LIQUIDATION_KEEPER role on keeper wallet
-    -> required before executeLiquidation() can succeed
-
-  order-execution-keeper price pushes running
-    -> stored prices present in PythLazerFeedProvider
-    -> scanner.getTokenPrice() returns non-null
-    -> executor oracle params built with real price data
-
-  Test position created and goes underwater
-    -> Reader.isPositionLiquidatable() returns true
-    -> Candidate created in PostgreSQL
-    -> executor.execute() called
-    -> LiquidationHandler.executeLiquidation() succeeds on-chain
-    -> Confirmator sees OrderExecuted event
-    -> Execution marked MINED
-
-Phase C: Performance and Reliability (independent of Phase B outcome)
-  Position-key deduplication guard (executor Map)
-    -> independent; can be added before Phase B
-    -> complements existing scanRunning flag
-
-  REVERTED status in confirmator
-    -> independent; add receipt.status check alongside existing MINED logic
-
-  Per-stage timing instrumentation
-    -> independent; no dependencies; adds observability
-
-  Batched multicall for position discovery
-    -> depends on publicClient multicall (already enabled)
-    -> independent of Phases A and B
-    -> only matters at scale (>50 positions)
+Connection resilience ──────> Required by ALL WS consumers (frontend + keeper-to-Hermes)
+Stale price indicator ──────> Required by ALL frontend WS consumers
 ```
 
-## MVP Recommendation for v1.7
+**Key ordering constraint:** Keeper must stream from Pyth Hermes first, then expose its own WS endpoint, then frontend can consume. Cannot build frontend WS without keeper WS server.
 
-**Phase A: Contract Bug Fix (do first — prerequisite)**
-1. Add `triggerPrice=0` guard in OrderHandler.sol for reversed markets
-2. Redeploy; update all service configs; re-run E2E tests (expect 18/18 pass)
+## Vercel Proxy Constraint
 
-**Phase B: End-to-End Verification (core goal)**
-3. Verify LIQUIDATION_KEEPER role granted to keeper wallet address on LiquidationHandler
-4. Verify order-execution-keeper is running and stored prices are fresh (`getStoredPrice()` returns non-null with age <60s)
-5. Create a test long/short position, reduce collateral below liquidation threshold (or use extreme market movement), confirm: scanner detects → executor submits → confirmator confirms
+**Critical architecture issue:** The current frontend proxies keeper HTTP requests through Vercel serverless functions (`api/keeper.ts`). Vercel serverless functions **cannot hold WebSocket connections** -- they are request/response only with execution time limits.
 
-**Phase C: Reliability Hardening (once Phase B passes)**
-6. Add position-key deduplication guard in executor (Map with 60s TTL)
-7. Add `REVERTED` status handling in confirmator (check `receipt.status`)
-8. Add per-stage timing instrumentation matching order-execution-keeper pattern
+**Recommendation:** Frontend connects directly to keeper for WS (`wss://<keeper-ip>:37017/ws` or a dedicated WS port with TLS). Keep Vercel proxy for REST endpoints only (candle history, health checks). This is standard for DeFi -- the WS endpoint is a separate URL from the REST API.
 
-**Defer:**
-- Batched multicall position discovery: only matters when >50 positions open on testnet. Premature optimization.
-- Scan-cycle counters in health endpoint: useful but not blocking any verification step.
+Options considered:
+- Direct WS to keeper IP (simplest, acceptable for testnet, exposes keeper IP)
+- Cloudflare Workers/Durable Objects as WS proxy (overkill for testnet)
+- Nginx reverse proxy on DO droplet with TLS termination (good for production, adds ops complexity)
 
-## What Makes a Liquidation Keeper Fast and Reliable
+For v1.12 testnet: direct connection is the right call.
 
-Based on analysis of the existing keeper-service codebase and prior phase research:
+## MVP Recommendation
 
-**Speed levers (ordered by impact for this system):**
+Prioritize (in dependency order):
 
-1. **Oracle freshness at execution time** — The largest single source of reverts. If `PythLazerFeedProvider.getStoredPrice()` returns stale data (>60s old per scanner check, or >MAX_ORACLE_PRICE_AGE per contract check), the call reverts. The cross-service dependency on order-execution-keeper's 5s update cadence must be operationally stable.
+1. **Keeper Hermes SSE** -- Replace `setInterval(tick, 2000)` with `HermesClient.getStreamingPriceUpdates()`. Lowest risk, immediate candle accuracy improvement, single file change.
+2. **Keeper WS endpoint** -- Add `ws` server to keeper-service that broadcasts ticker + candle updates to connected clients. New code but straightforward pub/sub.
+3. **Frontend mark prices via WS** -- Replace SWR polling in `useTokenRecentPricesRequest` with WS subscription. Single integration point that updates all downstream components.
+4. **TradingView subscribeBars via WS** -- Wire `DataFeed.subscribeBars` to consume WS candle updates instead of polling `fetchCandles`. Fixes chart staleness.
+5. **Connection resilience + stale indicator** -- Reconnect logic and stale price warning. Must ship alongside any WS feature.
 
-2. **Scan interval** — 30s default means a liquidatable position sits unaddressed for up to 30s. For testnet acceptability is fine. For mainnet competition, 5–10s is the right target. This is a single config change.
-
-3. **Account discovery efficiency** — Current `discoverAccountsWithPositions()` does N serial `getPosition()` calls inside a `getBytes32ValuesAt()` batch. With multicall batching, N calls become N/batchSize round-trips. With 100 positions, this changes from ~100 serial calls to 1 multicall. Large throughput improvement at scale; negligible at testnet scale.
-
-4. **Flashblocks RPC for TX submission** — order-execution-keeper already uses Flashblocks (~200ms preconfirmations). keeper-service could adopt the same for `executeLiquidation` submission. However, scan interval dominates latency here: even with Flashblocks, if the next scan is 30s away, confirmation speed doesn't matter. Adopt Flashblocks only after reducing scan interval.
-
-**Reliability levers (ordered by risk):**
-
-1. **Cross-service oracle dependency** — The keeper-service has no price feed of its own; it reads prices that order-execution-keeper writes. If the order-execution-keeper restarts or misconfigures, stored prices go stale within 60s and all liquidations fail silently. Operational monitoring of both services together is critical.
-
-2. **Deduplication guard** — Without an in-flight guard on position keys, a scan running while a liquidation TX is in-flight could submit a second TX on the same position. The second TX reverts (position closed) and wastes gas. Given 30s scan intervals and <200ms Flashblocks confirmations, the actual risk window is tiny — but the guard is 5 lines and eliminates it entirely.
-
-3. **REVERTED tracking** — Without `receipt.status` checking in the confirmator, a reverted liquidation TX permanently stalls its execution record in SUBMITTED status. The next scan cycle will re-detect the position (still liquidatable, since the TX reverted) and attempt again — but the stale execution record creates noise.
-
-4. **Role verification at startup** — If the keeper wallet loses the LIQUIDATION_KEEPER role (e.g., contract redeployment without re-granting), all executions will revert with AccessControl errors. A startup check that verifies the role prevents silent failure for the full keeper lifetime.
+Defer:
+- **Multi-resolution streaming**: Current approach (fetch candles, TradingView aggregates) works. Enhancement, not a fix.
+- **Binary encoding**: JSON is fine for 6 markets on testnet.
+- **Ticker snapshot on connect**: Nice to have, can add in same milestone if time permits.
 
 ## Sources
 
-- Direct source code analysis (HIGH confidence):
-  - `keeper-service/src/core/scanner.ts` — full scan loop, account discovery, liquidatability check, oracle price read
-  - `keeper-service/src/core/executor.ts` — oracle param building, gas estimation, TX submission, status tracking
-  - `keeper-service/src/core/confirmator.ts` — event watching, MINED status update
-  - `keeper-service/src/core/positionFetcher.ts` — sequential position fetching loop
-  - `keeper-service/src/core/pythLazerOracle.ts` — 200ms WebSocket price cache
-  - `keeper-service/src/index.ts` — scan loop, scan interval, startup sequence
-  - `keeper-service/src/config.ts` — SCAN_INTERVAL_SECONDS default (30)
-- Contract source analysis (HIGH confidence):
-  - `0xmarkets_contract/contracts/exchange/LiquidationHandler.sol` — `onlyLiquidationKeeper` modifier, `withOraclePrices` modifier confirmed
-  - `0xmarkets_contract/contracts/liquidation/LiquidationUtils.sol` — `triggerPrice=0` in liquidation order creation (source of reversed-market bug)
-- `.planning/PROJECT.md` — milestone scope, known issues, keeper infrastructure, Oracle mode
-- `.planning/phases/14-execution-speed/14-RESEARCH.md` — Flashblocks RPC patterns, per-stage timing, oracle sync patterns (HIGH confidence, verified in that phase)
+- [Pyth Hermes SSE streaming endpoint](https://docs.pyth.network/price-feeds/core/fetch-price-updates) -- `/v2/updates/price/stream` with `ids[]` params, auto-closes after 24h -- HIGH confidence
+- [Pyth Hermes architecture](https://docs.pyth.network/price-feeds/core/how-pyth-works/hermes) -- Hermes monitors Pythnet + Wormhole, exposes SSE + REST -- HIGH confidence
+- [TradingView streaming implementation guide](https://www.tradingview.com/charting-library-docs/latest/tutorials/implement_datafeed_tutorial/Streaming-Implementation/) -- subscribeBars rules: bar time = period start, only update most recent, async callbacks -- HIGH confidence
+- [Hyperliquid WebSocket API](https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/websocket) -- Subscription model, auto-reconnect pattern, snapshot on connect -- MEDIUM confidence (competitor reference)
+- Codebase analysis: `candleCollector.ts`, `DataFeed.ts`, `oracleKeeperFetcher.ts`, `useTokenRecentPricesData.ts`, `WebsocketContextProvider.tsx`, `api/keeper.ts` -- HIGH confidence
 
 ---
-*Research completed: 2026-02-27*
-*Replaces: v1.5 FEATURES.md (2026-02-25) — that covered the minimal keeper rewrite; this covers v1.7 liquidation verification scope*
+*Research completed: 2026-03-05*
+*Replaces: v1.7 FEATURES.md (2026-02-27) -- that covered liquidation verification; this covers v1.12 WebSocket streaming scope*

--- a/.planning/research/PITFALLS.md
+++ b/.planning/research/PITFALLS.md
@@ -1,200 +1,127 @@
-# Domain Pitfalls
+# Domain Pitfalls: WebSocket Price Streaming
 
-**Domain:** Contract redeployment in multi-service ecosystem + liquidation keeper verification and optimization
-**Researched:** 2026-02-27
-**Confidence:** HIGH (based on direct codebase analysis of all five services and known production incidents)
+**Domain:** Adding WebSocket streaming to an existing DeFi trading interface
+**Researched:** 2026-03-05
+**Context:** Keeper on DigitalOcean (Express on port 37017), frontend on Vercel, currently HTTP polling at 1-2s intervals
 
 ---
 
 ## Critical Pitfalls
 
-Mistakes that cause reverts, stuck positions, or silent keeper failures.
+Mistakes that cause outages, data corruption, or require architectural rework.
 
 ---
 
-### Pitfall 1: ExchangeRouter Immutable Constructor — Redeploying OrderHandler Alone Silently Fails
+### Pitfall 1: Vercel Cannot Terminate WebSocket Connections
 
-**What goes wrong:**
-OrderHandler is fixed and redeployed. The fix works when called directly. But all user transactions flow through ExchangeRouter, which stores `orderHandler` as an `immutable` Solidity field set at construction time. The old ExchangeRouter still points to the old (buggy) OrderHandler address. Users submitting JPY orders continue to get division-by-zero reverts. The keeper executes deposits and withdrawals fine. Only orders fail. This looks like the fix didn't work.
+**What goes wrong:** You try to serve WebSocket connections from the keeper through Vercel's proxy/CDN layer. Vercel Serverless Functions do not support WebSocket connections. The frontend currently fetches prices via `oracleKeeperFetcher` which hits URLs configured in `sdk/configs/oracleKeeper.ts`. If that URL routes through Vercel, WebSocket upgrade requests will fail silently or return opaque 502 errors.
 
-**Why it happens:**
-The natural instinct is "I'm fixing OrderHandler, so I deploy OrderHandler." But ExchangeRouter's constructor takes `OrderHandler` as a direct address argument baked into bytecode (`immutable`). It cannot be updated post-deployment. This is confirmed by the deploy script at `/Users/ken/Projects/0xM/0xmarkets_contract/deploy/deployExchangeRouter.ts` — `constructorContracts` explicitly includes `"OrderHandler"`.
+**Why it happens:** The existing HTTP polling works through Vercel's proxy because each request is stateless. WebSocket requires a persistent HTTP Upgrade handshake that Vercel's edge network does not support. Developers assume "if HTTP works through Vercel, WebSocket will too."
 
-**Consequences:**
-- JPY market orders continue to revert despite fix
-- Confusion about whether the fix was applied correctly
-- Developers spend hours re-verifying the Solidity fix when the real problem is stale wiring
+**Consequences:** WebSocket connections fail on the frontend. Users get no price updates. No error in keeper logs because the connection never reaches the keeper.
 
 **Prevention:**
-Always redeploy ExchangeRouter immediately after redeploying OrderHandler. Never test the fix through direct calls to OrderHandler — always test through ExchangeRouter to catch wiring issues.
+- Frontend WebSocket must connect DIRECTLY to the keeper's public endpoint, bypassing Vercel entirely.
+- Set up a separate DNS record (e.g., `ws.0xmarkets.io`) pointing to the DO droplet (142.93.203.222) for WebSocket traffic.
+- Keep the existing HTTP `/prices/tickers` endpoint alive as a fallback -- WebSocket is an enhancement, not a replacement.
+- If nginx is added on the DO droplet for TLS termination, configure `proxy_http_version 1.1`, `proxy_set_header Upgrade $http_upgrade`, `proxy_set_header Connection "upgrade"`, and `proxy_read_timeout 86400s`.
 
-**Verification:**
-After deployment, call `cast call <NEW_EXCHANGE_ROUTER> "orderHandler()(address)"` and confirm it returns the new OrderHandler address, not the old one (`0xCf752B72B74eE7b35a405c445E9843968f53A397`).
+**Detection:** WebSocket `onerror` fires immediately after `new WebSocket(url)`. Connection never reaches `onopen`. Browser DevTools Network tab shows the upgrade request failing with a non-101 status.
 
-**Phase to address:** Phase 24 (contract bug fixes) — must be a single atomic deployment step: fix → compile → deploy OrderHandler → deploy ExchangeRouter.
+**Warning signs:** Any WebSocket URL containing `vercel.app` or routed through a Vercel-hosted domain without explicit WebSocket support.
+
+**Phase:** Must be decided in Phase 1 (architecture/infrastructure). Wrong proxy path wastes all subsequent work.
 
 ---
 
-### Pitfall 2: CONTROLLER Role Not Granted to New Contracts — onlyController Reverts
+### Pitfall 2: Silent Connection Death Without Application-Level Heartbeat
 
-**What goes wrong:**
-New OrderHandler or ExchangeRouter is deployed. Transactions begin reverting with an access control error (not the original bug). The new contract was deployed but the `RoleStore.grantRole` transaction failed silently, was skipped, or the deployer lacked sufficient gas. The `onlyController` modifier on all handler functions checks `roleStore.hasRole(CONTROLLER, msg.sender)` — without the role, nothing executes.
+**What goes wrong:** The WebSocket connection drops silently -- no `close` event fires, no `error` event fires. The frontend shows stale prices for minutes without any indication. The keeper thinks the client is still connected and keeps buffering messages into the void.
 
-**Why it happens:**
-The `afterDeploy` hook in `deployOrderHandler.ts` calls `grantRoleIfNotGranted(deployedContract.address, "CONTROLLER")`. If this hook throws or is skipped (network hiccup, insufficient gas, deployer nonce conflict), the deployment artifact is written with the new address but the on-chain role was never granted. Hardhat does not fail the overall deployment in all cases when `afterDeploy` throws — it depends on the version and error type.
+**Why it happens:** TCP connections can die silently due to NAT timeout (commonly 60-300s on consumer routers), mobile network transitions, laptop sleep/wake, or intermediate load balancers dropping idle connections. The `ws` library in Node.js does NOT send ping frames automatically. The WebSocket protocol's ping/pong frames are not always forwarded by all intermediaries.
 
-**Consequences:**
-- All order execution reverts with access control error
-- Keeper logs show transaction reverted, no useful revert reason
-- The deployment artifact looks correct (new address) but the contract is non-functional
+**Consequences:** Users see frozen prices and think the platform is live. They make trading decisions on data that stopped updating minutes ago. On the server side, dead connections accumulate, consuming memory (compounding Pitfall 4).
 
 **Prevention:**
-After every deployment, explicitly verify roles using `cast`:
-```bash
-cast call <ROLE_STORE> "hasRole(bytes32,address)(bool)" $(cast keccak "CONTROLLER") <NEW_ORDER_HANDLER> --rpc-url https://sepolia.base.org
-cast call <ROLE_STORE> "hasRole(bytes32,address)(bool)" $(cast keccak "CONTROLLER") <NEW_EXCHANGE_ROUTER> --rpc-url https://sepolia.base.org
-cast call <ROLE_STORE> "hasRole(bytes32,address)(bool)" $(cast keccak "ROUTER_PLUGIN") <NEW_EXCHANGE_ROUTER> --rpc-url https://sepolia.base.org
-```
+- Implement server-side heartbeat: `ws.ping()` every 15-20 seconds. Track last pong timestamp per client. Terminate clients that miss 2 consecutive pongs (`ws.terminate()`, not `ws.close()`).
+- Implement client-side staleness detection: track `lastMessageTime`. If no message received for 10 seconds, assume dead connection and trigger reconnection. Display a "Reconnecting..." indicator in the UI.
+- Add a price staleness indicator: if the most recent price update's `publishTime` is older than 5 seconds, show a warning badge next to the price.
+- If nginx sits in front of the keeper, set `proxy_read_timeout 86400s` (default 60s silently kills idle WebSocket connections).
 
-All three must return `true`. If any returns `false`, manually call `grantRole` from the RoleStore admin account.
+**Detection:** Monitor connected client count over time on the keeper. A count that only grows (never decreases) indicates silent deaths accumulating. Check `healthState` for divergence between `wsConnected` and actual active client count.
 
-**Phase to address:** Phase 24 — add explicit role verification as a mandatory post-deployment step before marking the phase complete.
+**Warning signs:** Users reporting "prices froze" without seeing any error toast. Keeper memory slowly growing.
+
+**Phase:** Phase 1 (keeper WebSocket server) must include heartbeat from day one. Retrofitting heartbeat after deployment means a period of silent failures in production.
 
 ---
 
-### Pitfall 3: Stale Addresses Across Five Services After Redeployment
+### Pitfall 3: Dual-Source Race Condition During Migration
 
-**What goes wrong:**
-OrderHandler and ExchangeRouter are redeployed with new addresses. The Interface is updated. But keeper-service and order-execution-keeper-service still have the old ExchangeRouter address in their `.env` files. The keepers attempt to execute operations against the old contracts, which silently succeed (the transactions go through) but execute against a contract that is no longer the canonical entry point. Worse, if the old ExchangeRouter's roles were revoked as part of cleanup, all keeper transactions revert.
+**What goes wrong:** During the transition period, both HTTP polling and WebSocket are active. A stale HTTP response arrives AFTER a fresh WebSocket update, overwriting the latest price with an older one. Prices visibly jump backward.
 
-**Why it happens:**
-The address update guide in `.claude/contract-address-update-guide.md` lists the full checklist, but it is easy to miss individual service `.env` files — especially on the DigitalOcean droplet which has its own live `.env` files that differ from the local development copies.
+**Why it happens:** The frontend currently uses `useTokenRecentPricesRequest` with SWR `refreshInterval: 1000` (in `src/lib/timeConstants.ts`). This will keep firing even after a WebSocket connection is established. HTTP responses have variable latency (50-500ms). WebSocket messages arrive near-instantly. Without timestamp comparison, last-write-wins means a slow HTTP response can overwrite a faster WebSocket update.
 
-**The five services that must be updated:**
-1. Interface: `sdk/src/configs/contracts.ts`, `src/config/multichain.ts`
-2. keeper-service: `src/config.ts` (env vars) + DO droplet `.env`
-3. order-execution-keeper-service: `.env` + DO droplet `.env`
-4. 0xMarkets-squid: `src/processor.ts` (EventEmitter address only, unchanged here)
-5. 0xmarkets_contract: deployment artifacts (auto-updated by hardhat-deploy)
-
-**The DO droplet danger:** The deployed services on `142.93.203.222` have their own `.env` files that are NOT automatically updated when you update local files. After local `.env` changes are verified, the updated configs must be pushed to the droplet and both keeper services must be restarted.
+**Consequences:** Price jitter. Users see prices flip between two values. PnL calculations oscillate. Trading decisions made on incorrect prices. The UI feels broken even though both data sources are individually correct.
 
 **Prevention:**
-Run the on-chain DataStore verification script after every deployment. The pattern from Phase 20 (contract address audit) reads the DataStore's canonical addresses directly from the chain and compares them against each service's configured values. Discrepancies fail loudly.
+- Every price update (HTTP or WebSocket) must carry Pyth's `publish_time` timestamp (already present in both `pricesController.ts` ticker response and candle collector data).
+- Frontend state update logic: only accept a price if its `publishTime` >= the currently displayed price's `publishTime`.
+- When WebSocket connects successfully and receives its first price update, STOP the SWR polling interval (set `refreshInterval: 0` or conditionally disable the fetcher). Re-enable polling only on WebSocket disconnect after a grace period (5 seconds).
+- Never run both sources simultaneously for the same data in steady state.
 
-**Detection:** After redeployment, run a test deposit through the UI. If the keeper's transaction shows a revert reason related to "invalid handler" or "access denied," a service has a stale address.
+**Detection:** Add a counter for "rejected stale updates" in the frontend. If this counter is non-zero after WebSocket is stable, the race condition is active. Price values that oscillate between two distinct numbers at ~1Hz indicate the race.
 
-**Phase to address:** Phase 24 — the post-deployment checklist must include explicit address propagation to the DO droplet.
+**Warning signs:** After adding WebSocket, prices "flicker" or "jump" on the trade page. PnL values oscillate without trades happening.
 
----
-
-### Pitfall 4: Nonce Conflicts Between keeper-service and order-execution-keeper-service Sharing One Wallet
-
-**What goes wrong:**
-Both keepers run with the same `PRIVATE_KEY` environment variable, meaning they share the same Ethereum account and therefore share the same nonce sequence. The order-execution-keeper uses manual nonce management: `getTransactionCount({ blockTag: "latest" })` before each submission. If keeper-service's liquidation executor submits a transaction simultaneously, both keepers read the same "current" nonce, both try to submit with that nonce, and one wins while the other gets `replacement transaction underpriced`. The loser's error handling may then retry with the same stale nonce, compounding the problem.
-
-**The critical asymmetry:** The order-execution-keeper has a well-tested sequential executor with nonce error recovery (`extractExpectedNonce`). The keeper-service's liquidation executor (`/src/core/executor.ts`) does NOT use this pattern — it calls `estimateFeesPerGas()` and `writeContract()` without manual nonce management, relying on viem's default behavior.
-
-**Why it happens:**
-Using a single keeper wallet is documented as an intentional "simpler for testnet" decision (`PROJECT.md` Key Decisions). It was acceptable when keeper-service only did price feeds and candles (no transactions). Liquidation execution adds transaction submission to keeper-service, creating genuine concurrency.
-
-**Current mitigations present:**
-- order-execution-keeper has `extractExpectedNonce` and retries with corrected nonce on "nonce too low"
-- Sequential executor design means order-execution-keeper only has one in-flight TX at a time
-- keeper-service liquidation executor has no concurrency protection
-
-**Consequence:** Liquidation execution and order/deposit/withdrawal execution will collide under concurrent load. The liquidation TX or the deposit TX will revert. The deposit will be retried (it stays in the DataStore). The liquidation candidate will be marked `FAILED` in the keeper-service database and never retried.
-
-**Prevention options (in order of preference):**
-1. **Separate wallets (recommended for production):** Give keeper-service its own funded wallet with `LIQUIDATION_KEEPER` role. Completely eliminates the conflict. Zero code changes needed beyond a new `.env` var.
-2. **Transaction mutex shared across both keepers (testnet shortcut):** Not feasible — two separate processes, no shared memory.
-3. **Stagger execution windows:** Configure keeper-service to delay liquidation execution by 3 seconds after order-execution-keeper's last known submission time. Not reliable under load.
-4. **Accept conflicts as rare for testnet:** On testnet with low traffic, simultaneous liquidation + order execution is unlikely. The order-execution-keeper's `extractExpectedNonce` recovery handles most cases. Acceptable for v1.7 verification but must be fixed before production.
-
-**Detection:** Watch for `replacement transaction underpriced` or `nonce too low` errors in keeper-service logs at the same time that order-execution-keeper logs show normal execution. The timing correlation identifies a nonce conflict.
-
-**Phase to address:** Phase 24 or a dedicated wallet-split phase. For v1.7 (testnet verification), document this as a known risk. Mark it blocking for any production deployment.
+**Phase:** Phase 3 (frontend WebSocket integration). The frontend migration phase must handle this explicitly.
 
 ---
 
-### Pitfall 5: Liquidation Executor Uses `getStoredPrice` With 60-Second Staleness Check — Depends on order-execution-keeper Staying Alive
+### Pitfall 4: Keeper Memory Exhaustion from Slow/Dead Clients
 
-**What goes wrong:**
-The keeper-service liquidation executor's `getTokenPrice` method reads prices from `PythLazerFeedProvider.getStoredPrice()` on-chain, with a 60-second staleness guard (`nowSeconds - storedPrice.timestamp > 60n`). This design assumes the order-execution-keeper is continuously pushing fresh prices to the `PythLazerFeedProvider` contract. If the order-execution-keeper goes down (Docker restart, crash, temporary OOM), the stored prices go stale within 60 seconds. The liquidation keeper then returns `null` for all token prices, skips all markets with a "stored price too stale" warning, and silently misses every liquidation opportunity during the downtime window.
+**What goes wrong:** The keeper's `ws` server buffers outgoing messages for slow clients. With 7 price feeds being relayed to N browser clients, the send buffer grows unboundedly for any client that cannot keep up. The keeper process OOMs and crashes, killing ALL services: liquidation scanner, order execution candle collector, and price feeds.
 
-**Why this is dangerous for liquidations specifically:** A liquidation that was valid at the time of the scan may become invalid if prices move. But a position that should be liquidated immediately (e.g., price spiked sharply against the position) needs to be acted on within the same scan window. If prices go stale for even 60 seconds during volatile market conditions, legitimate liquidations are skipped.
+**Why it happens:** The `ws` library's `send()` enqueues data in the Node.js TCP send buffer when the receiver is slow. There is no built-in backpressure mechanism. A single browser tab on a slow 3G connection, or a tab that went to sleep without closing the WebSocket, accumulates megabytes of buffered price updates on the server side. The keeper runs ALL critical services in a single Node.js process on a single DO droplet -- there is no process isolation.
+
+**Consequences:** Keeper crashes from OOM. ALL keeper functions go down simultaneously: liquidations stop, order execution stops, candle collection stops, price feeds stop. Full platform outage caused by a WebSocket feature that was supposed to be an enhancement.
 
 **Prevention:**
-1. The liquidation keeper should have its OWN Pyth Lazer WebSocket connection and cache (independent of order-execution-keeper's on-chain price storage). The `PythLazerOracleService` already exists in keeper-service — it just needs to be started in `lazer` oracle mode and `getTokenPrice` should read from the local cache, not from on-chain stored prices.
-2. The current keeper-service `index.ts` already initializes `PythLazerOracleService` when `ORACLE_MODE=lazer` — but the `scanner.ts` `getTokenPrice` method ignores this and reads from the contract instead.
-3. Minimum fix: change `getTokenPrice` to try the local Lazer cache first, fall back to on-chain stored price if the cache miss.
+- Check `ws.bufferedAmount` before each `send()`. If buffered data exceeds 64KB, skip the update for that client. Price updates are ephemeral -- a dropped update is always superseded by the next one.
+- Set a maximum client count (e.g., 50 for testnet). Reject new connections with HTTP 503 when at capacity.
+- Combine with heartbeat-based dead connection cleanup (Pitfall 2).
+- Rate-limit the relay: Pyth Lazer streams at 200ms intervals, but the frontend only needs ~500ms-1s updates. Throttle the broadcast to one message per 500ms.
+- Monitor keeper memory: log `process.memoryUsage().rss` every 30 seconds. Alert if RSS exceeds 400MB (or 80% of available).
+- Consider running the WebSocket server in a separate Node.js process (e.g., separate Docker container) to isolate it from the critical keeper loop. If the WS server OOMs, the liquidation scanner and order executor survive.
 
-**Detection:** If order-execution-keeper has a brief restart and liquidation scanner logs show "stored price too stale" for all tokens during that window, this pitfall is manifesting.
+**Detection:** `process.memoryUsage().rss` trending upward over hours without corresponding increase in client count. `ws.bufferedAmount > 0` growing for specific clients in periodic health logs.
 
-**Phase to address:** Phase 25 (liquidation verification) — fixing this dependency is part of making the liquidation path reliable.
+**Warning signs:** Keeper restarts without clear cause. Docker OOM-kill events in `docker logs`.
+
+**Phase:** Phase 1 (keeper WebSocket server). Backpressure handling must be built into the broadcast loop from the start. Process isolation decision should be made during architecture.
 
 ---
 
-### Pitfall 6: `discoverAccountsWithPositions` Fetches Every Position Key Individually — O(N) RPC Calls Per Scan
+### Pitfall 5: Mixed Content Blocking -- HTTPS Frontend Cannot Connect to Plain WS
 
-**What goes wrong:**
-`positionFetcher.discoverAccountsWithPositions()` in keeper-service:
-1. Reads `getBytes32Count(POSITION_LIST_KEY)` to get total count
-2. Reads position keys in batches of 100 via `getBytes32ValuesAt`
-3. For EACH position key, makes an individual `getPosition(dataStore, key)` RPC call to extract the account address
+**What goes wrong:** Frontend at `https://app.0xmarkets.io` (HTTPS via Vercel) tries to open `ws://142.93.203.222:37017` (plain WebSocket). Browser blocks the connection due to mixed content policy: an HTTPS page cannot load insecure WebSocket resources.
 
-With 1000 open positions, this is 1000 serial RPC calls per scan cycle. At ~100ms per call on Base Sepolia, one scan cycle takes 100 seconds — longer than the 30-second scan interval. The `scanRunning` guard prevents overlapping scans, so every scan cycle is skipped until the previous one finishes. Effective scan frequency degrades to once every 100 seconds at 1000 positions.
+**Why it happens:** The keeper currently serves plain HTTP on port 37017 via Express (`httpServer.ts`). There is no TLS termination on the DO droplet. The existing HTTP polling works because the frontend proxies through Vercel's HTTPS edge (or the keeper URL is already HTTPS). WebSocket connections bypass Vercel (Pitfall 1) and go directly to the keeper, exposing the lack of TLS.
 
-**Why it happens:**
-The `POSITION_LIST` in the DataStore stores position keys (`bytes32`), not the full position structs. To find which accounts have positions, you must decode each key back to an account — but position keys are hashes, not reversible. The only way to get the account is to read the full position struct from the contract.
-
-**Note for v1.7 testnet context:** With very few test positions (likely 5-20), this is not a problem. The pitfall becomes relevant at scale or during load testing.
+**Consequences:** `new WebSocket("ws://...")` fails silently in the browser. No connection is established. No error event fires in some browsers. The WebSocket feature appears completely broken with no obvious cause.
 
 **Prevention:**
-For now, document the O(N) limitation. The correct optimization is to use event-based account discovery: watch `PositionIncrease` events from EventEmitter to build an account registry, then only fetch positions for known accounts. This eliminates the DataStore iteration entirely. The `confirmator.ts` already watches the EventEmitter — extend it to track accounts with active positions.
+- Set up TLS on the DO droplet before writing any frontend WebSocket code. Options:
+  1. **nginx + Let's Encrypt** as reverse proxy (proven, well-documented)
+  2. **Caddy** for automatic HTTPS (simpler, auto-renews)
+- Use a proper domain (`wss://ws.0xmarkets.io`) instead of raw IP. Let's Encrypt requires a domain for certificate issuance.
+- Test the WebSocket connection from the actual deployed frontend URL, not from localhost (localhost is exempt from mixed content policies).
 
-**Detection:** Scan cycle duration in logs exceeds 30 seconds (the scan interval). "previous scan still running, skipping" warnings appear regularly.
+**Detection:** Browser console shows "Mixed Content: The page at 'https://...' was loaded over HTTPS, but attempted to connect to the insecure WebSocket endpoint 'ws://...'."
 
-**Phase to address:** Phase 25 (liquidation optimization) — document as a known scale bottleneck. Implement event-based account discovery when testnet positions exceed 50.
+**Warning signs:** WebSocket works in local development (`http://localhost:3000` to `ws://localhost:37017`) but fails completely on the deployed site.
 
----
-
-### Pitfall 7: `collateralUsd` in PositionSnapshot Is Not USD — It Is Raw Token Amount
-
-**What goes wrong:**
-`positionFetcher.ts` sets `collateralUsd = pos.numbers.collateralAmount`. The comment says `// TODO: Convert using collateral token price`. But `collateralAmount` is the raw token amount (e.g., USDC with 6 decimals, so 1000 USDC = `1_000_000` wei). The `RiskEngine.checkLiquidation` uses this raw value as if it were a USD amount (`const collateral = position.collateralUsd`). All risk calculations are wrong by orders of magnitude.
-
-**However:** The scanner in `scanner.ts` does NOT use `RiskEngine.checkLiquidation`. It calls `Reader.isPositionLiquidatable()` directly on-chain, which computes everything correctly using the contract's internal pricing. The `RiskEngine` is only used to compute a `riskScore` for the database record, not to decide whether to liquidate.
-
-**The consequence:** Risk scores in the database are wrong (will show extreme values). But liquidation decisions are based on the on-chain Reader call, which is correct. The bug is a data quality issue in the audit trail, not a correctness issue in the execution path.
-
-**Prevention:** Fix the `collateralUsd` calculation before relying on risk scores for any alerting or dashboarding. For v1.7, note this as a known data quality issue in the audit trail but not a blocker for functional correctness.
-
-**Phase to address:** Phase 25 (liquidation optimization) — fix the calculation as part of the risk scoring improvements.
-
----
-
-### Pitfall 8: Executor Re-Fetches Position From Contract After It May Have Changed
-
-**What goes wrong:**
-The liquidation execution flow in `executor.ts`:
-1. Scanner identifies a liquidatable position and saves a snapshot
-2. Scanner calls `executor.execute(candidate, decision)` synchronously
-3. Executor re-fetches the position from the contract via `positionFetcher.fetchAccountPositions`
-4. If no matching position is found (size > 0), the execution fails with "Position not found"
-
-Between step 1 (scanner decision) and step 3 (executor re-fetch), the position state on-chain may have changed:
-- The user closed their position voluntarily between the scan and the execution
-- Another keeper instance liquidated it first (impossible with single keeper, but relevant if testing with multiple)
-- The user added collateral and the position is no longer liquidatable
-
-**The double-fetch pattern:** The executor re-fetches the position specifically to get `collateralToken` and `isLong`, which are needed for `executeLiquidation(account, market, collateralToken, isLong, oracleParams)`. These are stored in the position struct but not reliably in the scanner's snapshot.
-
-**Consequence for closed positions:** The executor calls `executeLiquidation` with parameters from the snapshot for a position that no longer exists. The LiquidationHandler will revert because there is no position to liquidate. The executor catches the error and marks the candidate `FAILED`. This is correct behavior — but the `FAILED` status in the DB looks concerning and may trigger false alerts.
-
-**Prevention:** Treat `FAILED` liquidation executions as potentially benign (position closed before execution). Log them as INFO not ERROR when the position no longer exists at execution time. Do not alert on `FAILED` candidates without first checking whether the position still exists.
-
-**Phase to address:** Phase 25 — improve executor error classification to distinguish "position no longer exists" from genuine execution failures.
+**Phase:** Phase 1 (infrastructure). TLS setup is a prerequisite for all frontend WebSocket work.
 
 ---
 
@@ -202,64 +129,81 @@ Between step 1 (scanner decision) and step 3 (executor re-fetch), the position s
 
 ---
 
-### Pitfall 9: SKIP_HANDLER_DEPLOYMENTS Environment Variable Silently Skips OrderHandler Redeploy
+### Pitfall 6: Express and WebSocket Server Port Conflict
 
-**What goes wrong:**
-`deployOrderHandler.ts` has `func.skip = async () => process.env.SKIP_HANDLER_DEPLOYMENTS ? true : false`. If this variable is set in the shell environment (perhaps from a previous partial deployment session or a different project's dotenv), `npx hardhat deploy --tags OrderHandler` runs, appears to succeed (Hardhat reports "nothing to deploy"), but deploys nothing. The old buggy OrderHandler remains at its old address.
+**What goes wrong:** You try to attach the `ws` WebSocketServer to the same HTTP server that Express uses (port 37017). Without careful handling of the `upgrade` event, the WebSocket server and Express compete for incoming connections. Existing HTTP endpoints (`/health`, `/prices/tickers`, `/prices/candles`, `/api/*`) start failing intermittently or the WebSocket upgrade never completes.
 
-**Prevention:** Before deployment, explicitly verify `SKIP_HANDLER_DEPLOYMENTS` is unset:
-```bash
-echo $SKIP_HANDLER_DEPLOYMENTS  # must be empty
-unset SKIP_HANDLER_DEPLOYMENTS
-```
+**Why it happens:** Both Express and `ws` need to handle HTTP requests on the same port. The `upgrade` event fires for all HTTP upgrade requests. Without explicit path-based routing, the WebSocket server may intercept health check requests, or Express may respond to WebSocket upgrade requests with a 404.
 
-**Phase to address:** Phase 24 — add this verification to the pre-deployment checklist.
+**Prevention:**
+- **Option A (recommended for simplicity):** Run the WebSocket server on a separate port (e.g., 37019). Opens a new port on the firewall but completely avoids conflicts. The data-verification-service already uses 37019 -- use 37020 or another available port.
+- **Option B (shared port):** Use `ws` with `noServer: true` and manually route the `upgrade` event:
+  ```typescript
+  const wss = new WebSocketServer({ noServer: true });
+  server.on('upgrade', (req, socket, head) => {
+    if (req.url === '/ws/prices') {
+      wss.handleUpgrade(req, socket, head, (ws) => wss.emit('connection', ws, req));
+    } else {
+      socket.destroy(); // reject non-WS upgrade requests
+    }
+  });
+  ```
+- After adding WebSocket, explicitly test ALL existing HTTP endpoints to verify they still work.
 
----
-
-### Pitfall 10: hardhat-deploy Skips Redeployment If Bytecode Matches Cached Deployment
-
-**What goes wrong:**
-`hardhat-deploy` compares the new contract's bytecode against the cached deployment in `deployments/baseSepolia/`. If the bytecode matches (e.g., you compiled the same contract twice without changes), it skips deployment and uses the cached address. After fixing `OrderHandler.sol`, the bytecode will differ, so this is not a concern — unless the fix was reverted accidentally or the compilation produced the same bytecode via a no-op change.
-
-**Detection:** After `npx hardhat deploy --tags OrderHandler`, verify the address in `deployments/baseSepolia/OrderHandler.json` differs from the old address (`0xCf752B72B74eE7b35a405c445E9843968f53A397`). If the address is unchanged, the deployment was skipped.
-
-**Prevention:** Force redeployment if needed with `--reset` flag. Do not use `--reset` blindly — it redeploys ALL contracts, not just the targeted ones.
-
-**Phase to address:** Phase 24 — explicit address comparison is part of the post-deployment verification.
+**Phase:** Phase 1 (keeper WebSocket server). Architecture decision needed before implementation.
 
 ---
 
-### Pitfall 11: `withOraclePrices` Modifier Staleness Check Uses On-Chain Block Timestamp, Not Keeper Clock
+### Pitfall 7: Pyth Hermes Streaming Has Different Semantics Than HTTP Polling
 
-**What goes wrong:**
-The `LiquidationHandler.executeLiquidation` uses `withOraclePrices(oracleParams)` which calls `Oracle.setPrices`. Inside `Oracle.setPrices`, each price's timestamp is validated against `block.timestamp` with `MAX_ORACLE_PRICE_AGE` (300 seconds). The keeper's executor in `buildOracleParams` passes `update?.rawUpdate ?? "0x"` — when `rawUpdate` is "0x" (no cached update), the contract reads from stored prices via `PythLazerFeedProvider.getOraclePrice`, which returns whatever price was last pushed on-chain.
+**What goes wrong:** The candle collector (`candleCollector.ts`) currently calls `client.getLatestPriceUpdates()` every 2 seconds via HTTP. Switching to Hermes SSE/WebSocket changes the data delivery pattern: updates arrive push-based at variable frequency (sub-second), not on a fixed 2-second cadence. The candle-building logic may produce subtly different OHLC data.
 
-**The trap:** On-chain stored prices are updated by the order-execution-keeper every ~5 seconds. But the `timestamp` field stored in the contract comes from the Pyth Lazer feed's original timestamp, not `block.timestamp`. If there is any clock drift between the Pyth feed timestamp and the chain's `block.timestamp`, the `MAX_ORACLE_PRICE_AGE` check can fail even with fresh prices.
+**Why it happens:** The current `tick()` function samples at fixed 2s intervals. With streaming, you get every price Pyth publishes. The `floorToMinute()` and in-memory candle logic still works correctly, but:
+- "Open" is now the first streamed price of the minute (more accurate) rather than the first polled price (which could arrive up to 2s after the minute started).
+- High/low coverage improves dramatically (catches spikes between polls).
+- Volume of price updates per minute increases from ~30 to potentially hundreds, increasing CPU usage for candle processing.
+- Hermes SSE connections auto-disconnect after 24 hours to prevent resource leaks.
 
-**Prevention:** Test liquidation execution end-to-end on testnet before assuming it works. The oracle timestamp handling for liquidations may differ from deposit/withdrawal execution in subtle ways. Verify by observing actual `executeLiquidation` transactions on Basescan.
+**Prevention:**
+- The candle-building logic is actually correct for both polling and streaming -- it's stateless per-update. No code changes needed for correctness.
+- Add reconnection logic for the 24-hour disconnect: detect stream close, reconnect immediately.
+- Debounce database writes: the current pattern (flush previous candle when minute changes) already handles this correctly. Do not change to flush on every update.
+- Validate candle accuracy: compare streaming candles against HTTP-polled candles for a few hours before cutting over.
 
-**Phase to address:** Phase 25 — requires live testnet testing, not just code review.
+**Phase:** Phase 1 (keeper Pyth streaming). Test candle accuracy against HTTP baseline before removing the HTTP polling code path.
 
 ---
 
-### Pitfall 12: `onlyLiquidationKeeper` Role — keeper-service Must Have This Role Granted
+### Pitfall 8: Reconnection Thundering Herd After Keeper Restart
 
-**What goes wrong:**
-`LiquidationHandler.executeLiquidation` has `onlyLiquidationKeeper` modifier (visible in `LiquidationHandler.sol` line 46). The keeper-service wallet must have the `LIQUIDATION_KEEPER` role in the RoleStore. If this role was not granted when the keeper was originally set up (it is separate from `ORDER_KEEPER` and `CONTROLLER`), all liquidation transactions will revert with an access control error.
+**What goes wrong:** The keeper restarts (deploy, crash, OOM). All connected frontend clients detect the disconnect simultaneously and reconnect at the same instant. The keeper gets slammed with N simultaneous WebSocket upgrade requests plus subscription messages, potentially overloading it during the fragile startup period.
 
-**Why likely not yet verified:** The liquidation keeper has never been run end-to-end (it is "pending verification" per `PROJECT.md`). The role may or may not have been granted when the contract was originally deployed.
+**Why it happens:** All clients use the same reconnection delay without randomization. Reconnection attempts synchronize, creating a burst.
 
-**Prevention:** Before running the liquidation keeper for the first time, verify the role:
-```bash
-cast call <ROLE_STORE> "hasRole(bytes32,address)(bool)" $(cast keccak "LIQUIDATION_KEEPER") <KEEPER_WALLET_ADDRESS> --rpc-url https://sepolia.base.org
-```
-If it returns `false`, grant it:
-```bash
-cast send <ROLE_STORE> "grantRole(bytes32,address)" $(cast keccak "LIQUIDATION_KEEPER") <KEEPER_WALLET_ADDRESS> --rpc-url https://sepolia.base.org --private-key <ADMIN_KEY>
-```
+**Prevention:**
+- Frontend reconnection must use exponential backoff with random jitter: `delay = min(1000 * 2^attempt, 30000) + random(0, 3000)`.
+- The keeper should not broadcast accumulated/buffered messages on new connections -- just start fresh from the next price update.
+- Set a connection rate limit on the keeper: accept at most 10 new connections per second during startup.
+- After reconnecting, the frontend should immediately request the latest price via HTTP fallback (Pitfall 10) to avoid showing stale data during the reconnection window.
 
-**Phase to address:** Phase 25 — this is the first thing to check before any liquidation testing.
+**Phase:** Phase 3 (frontend WebSocket client). Reconnection logic is a frontend concern.
+
+---
+
+### Pitfall 9: Pyth Lazer WebSocket Confusion -- Two Different Pyth Connections for Different Purposes
+
+**What goes wrong:** The keeper already has ONE Pyth Lazer WebSocket connection (`PythLazerOracleService` in `pythLazerOracle.ts`) for on-chain oracle signing. Adding a second Pyth connection (Hermes for price streaming to the frontend) creates confusion about which connection serves which purpose. Developers modify the wrong connection, or assume one connection can serve both needs.
+
+**Why it happens:** Both connections talk to Pyth infrastructure, both deliver price data, but they serve completely different purposes:
+- **Pyth Lazer** (existing): `@pythnetwork/pyth-lazer-sdk`, binary EVM format, used for `updatePrice()` on-chain transactions. Cannot be repurposed for frontend streaming.
+- **Pyth Hermes** (new): `@pythnetwork/hermes-client`, parsed JSON format, used for display prices. Does not provide EVM-encoded data for on-chain use.
+
+**Prevention:**
+- Name modules distinctly: `pythLazerOracle.ts` (existing, oracle signing) vs `priceStreamer.ts` or `hermesPriceStream.ts` (new, price streaming).
+- Verify the Pyth Pro API key (`QpxMy21OMvC7rap9hYxJ6GB0eb3PdOEs2WvmG0XN`) supports both Lazer and Hermes concurrent connections without rate limiting.
+- Document the two connections clearly in the keeper's README or config comments.
+
+**Phase:** Phase 1 (keeper). Naming and separation must be clear from the start.
 
 ---
 
@@ -267,27 +211,42 @@ cast send <ROLE_STORE> "grantRole(bytes32,address)" $(cast keccak "LIQUIDATION_K
 
 ---
 
-### Pitfall 13: Scan Interval (30 seconds) May Miss Immediate Liquidation After Sharp Price Move
+### Pitfall 10: No Graceful Degradation When WebSocket Fails
 
-**What goes wrong:**
-The keeper-service scan runs every 30 seconds (`SCAN_INTERVAL_SECONDS=30`). If a position becomes liquidatable due to a sudden price spike, it is not detected until the next scan cycle completes, which could be up to 29 seconds after the price move. On testnet with low latency, this is acceptable. On mainnet with competitive liquidators, this means losing every liquidation to bots scanning at 1-second intervals.
+**What goes wrong:** WebSocket is deployed as the primary price source. When it fails (keeper restart, network blip, client-side WebSocket unsupported), the frontend shows no prices at all. Users cannot trade.
 
-**Prevention for v1.7:** 30 seconds is acceptable for testnet verification. Document the limitation. For production, the scan interval should be reduced to 2-5 seconds, and the oracle pricing should be pulled directly from the Lazer WebSocket cache (not from on-chain stored prices) to eliminate the oracle-freshness dependency during scanning.
+**Prevention:**
+- Keep the HTTP `/prices/tickers` endpoint operational. It is already built and working in `pricesController.ts`.
+- Frontend should automatically fall back to HTTP polling (the current `useTokenRecentPricesRequest` with 1s SWR) when WebSocket is disconnected for more than 5 seconds.
+- Display connection status: "Live" (WebSocket active), "Delayed" (HTTP polling fallback), "Offline" (both failed).
+- The fallback must be tested: kill the WebSocket server while the frontend is running and verify prices continue updating via HTTP.
 
-**Phase to address:** Phase 25 (optimization) — scan interval tuning is a performance parameter, not a correctness issue.
+**Phase:** Phase 3 (frontend). Fallback logic is part of the frontend WebSocket integration.
 
 ---
 
-### Pitfall 14: PostgreSQL Database Must Be Migrated Before keeper-service Restart
+### Pitfall 11: Browser Tab Backgrounding Wastes Resources
 
-**What goes wrong:**
-The keeper-service uses Prisma with a PostgreSQL database. If the schema changes (new fields, renamed tables) between deployments without running `prisma migrate deploy`, the service crashes on startup with a Prisma schema mismatch error.
+**What goes wrong:** WebSocket messages keep arriving when the browser tab is in the background. Each message triggers React state updates via the price store, causing unnecessary renders and CPU usage. On mobile, this drains battery and may cause the OS to kill the tab.
 
-**For v1.7:** No schema changes are planned. The liquidation tables (`position_snapshots`, `liquidation_candidates`, `signed_decisions`, `liquidation_executions`) already exist from the initial keeper-service deployment.
+**Prevention:**
+- Use the Page Visibility API (`document.visibilityState`). When hidden for more than 30 seconds, stop processing incoming WebSocket messages (but keep connection alive to avoid reconnection cost). Resume processing when visible.
+- The current SWR polling uses `refreshWhenHidden: true`. Decide whether WebSocket should match this behavior or be smarter. For a trading app, keeping prices fresh in background tabs is reasonable -- but throttle to 5s updates instead of real-time.
 
-**Prevention:** If schema changes are ever made, always run `prisma migrate deploy` on the DO droplet before restarting the service. The database is on the same droplet; SSH in and run it manually.
+**Phase:** Phase 3 (frontend optimization). Not a launch blocker but improves mobile experience.
 
-**Phase to address:** Not a v1.7 concern unless schema changes are introduced.
+---
+
+### Pitfall 12: WebSocket Message Format Breaking Changes
+
+**What goes wrong:** The keeper broadcasts prices in a specific JSON format. Frontend parses this format. A keeper deploy changes the format (field renamed, new field added, precision changed). Frontend breaks until redeployed.
+
+**Prevention:**
+- Define a versioned message schema. Include a `version` field in every WebSocket message (e.g., `{ version: 1, type: "prices", data: [...] }`).
+- Frontend should validate incoming messages and gracefully ignore unknown versions (fall back to HTTP).
+- Deploy keeper changes before frontend changes. The keeper's HTTP `/prices/tickers` format is the contract -- the WebSocket format should match it exactly.
+
+**Phase:** Phase 1 (keeper). Define the message format specification before implementing either side.
 
 ---
 
@@ -295,48 +254,45 @@ The keeper-service uses Prisma with a PostgreSQL database. If the schema changes
 
 | Phase Topic | Likely Pitfall | Mitigation |
 |-------------|---------------|------------|
-| OrderHandler redeploy | ExchangeRouter immutable constructor not updated | Always deploy ExchangeRouter immediately after OrderHandler |
-| ExchangeRouter redeploy | CONTROLLER/ROUTER_PLUGIN roles not granted | Verify with `cast call` before any testing |
-| Address propagation to DO droplet | Stale addresses in live `.env` files | SSH to droplet, update `.env`, restart both keepers |
-| Liquidation first run | LIQUIDATION_KEEPER role not granted | Check role before first execution attempt |
-| Nonce management | Both keepers share wallet, concurrent TXs | Separate wallets or accept testnet race condition with documented risk |
-| Oracle for liquidations | Depends on order-execution-keeper's on-chain price store | Verify freshness window; use local Lazer cache for independence |
-| Account discovery | O(N) per-position RPC calls | Acceptable at testnet scale; document as scale blocker |
-| Risk score accuracy | collateralUsd is raw token amount, not USD | Non-blocking for v1.7; fix before using scores for alerts |
-| Skip flag on deployment | SKIP_HANDLER_DEPLOYMENTS env var skips redeploy silently | Unset before running hardhat deploy |
-| hardhat-deploy cache | Unchanged bytecode skips redeploy | Verify new address differs from old after deployment |
-| Oracle timestamp validation | On-chain timestamp vs block.timestamp drift | Verify with actual testnet liquidation execution |
-
----
-
-## Recovery Strategies
-
-| Pitfall | Recovery Steps |
-|---------|---------------|
-| ExchangeRouter still points to old OrderHandler | Redeploy ExchangeRouter immediately; update all service addresses |
-| CONTROLLER role missing | Call `grantRole(CONTROLLER, newAddress)` from RoleStore admin; no redeployment needed |
-| LIQUIDATION_KEEPER role missing | Call `grantRole(LIQUIDATION_KEEPER, keeperWallet)` from RoleStore admin |
-| Stale addresses on DO droplet | SSH to `142.93.203.222`, update `.env` for both keepers, `docker compose restart` both services |
-| Nonce conflict between keepers | Let it resolve naturally (order-execution-keeper has recovery); if stuck, restart both keepers and let them re-sync nonces from chain |
-| Liquidation executor marks candidates FAILED | Check whether position still exists on-chain; if position was closed legitimately, FAILED status is correct. Re-check logic if position still exists. |
-| SKIP_HANDLER_DEPLOYMENTS silently skipped deploy | Unset the var, run deployment again; hardhat-deploy will compare bytecode and redeploy correctly |
+| Infrastructure / TLS | Pitfall 5: mixed content blocking | Set up nginx + Let's Encrypt on DO droplet FIRST |
+| Infrastructure / DNS | Pitfall 1: Vercel cannot proxy WS | Create `ws.0xmarkets.io` DNS record pointing to DO |
+| Keeper WebSocket server | Pitfall 6: port conflict with Express | Use `noServer: true` or separate port |
+| Keeper WebSocket server | Pitfall 4: memory exhaustion from slow clients | Check `bufferedAmount`, set client cap, implement heartbeat |
+| Keeper WebSocket server | Pitfall 2: silent connection deaths | Server-side ping/pong every 15s, terminate after 2 missed pongs |
+| Keeper WebSocket server | Pitfall 12: format breaking changes | Define versioned message schema upfront |
+| Keeper Pyth streaming | Pitfall 7: candle semantics change | Validate candle accuracy against HTTP baseline |
+| Keeper Pyth streaming | Pitfall 9: Lazer/Hermes confusion | Name modules distinctly, separate concerns |
+| Frontend WebSocket client | Pitfall 3: race condition with HTTP polling | Timestamp-gated updates, disable polling when WS active |
+| Frontend WebSocket client | Pitfall 8: thundering herd on reconnect | Exponential backoff with random jitter |
+| Frontend fallback | Pitfall 10: no degradation path | Keep HTTP endpoint, auto-fallback after 5s disconnect |
+| Frontend optimization | Pitfall 11: background tab waste | Page Visibility API throttling |
 
 ---
 
 ## Sources
 
-### Primary (HIGH confidence — direct codebase analysis)
-- `/Users/ken/Projects/0xM/0xmarkets_contract/deploy/deployOrderHandler.ts` — SKIP_HANDLER_DEPLOYMENTS skip logic, afterDeploy role grants
-- `/Users/ken/Projects/0xM/0xmarkets_contract/deploy/deployExchangeRouter.ts` — immutable OrderHandler constructor arg, afterDeploy role grants
-- `/Users/ken/Projects/0xM/0xmarkets_contract/contracts/exchange/LiquidationHandler.sol` — onlyLiquidationKeeper modifier, executeLiquidation signature
-- `/Users/ken/Projects/0xM/keeper-service/src/core/scanner.ts` — discoverAccountsWithPositions O(N) pattern, getStoredPrice 60s staleness check
-- `/Users/ken/Projects/0xM/keeper-service/src/core/executor.ts` — no nonce management, double-fetch pattern, gas estimation
-- `/Users/ken/Projects/0xM/keeper-service/src/core/positionFetcher.ts` — collateralUsd = collateralAmount bug
-- `/Users/ken/Projects/0xM/keeper-service/src/core/riskEngine.ts` — uses collateralUsd as USD value (incorrect)
-- `/Users/ken/Projects/0xM/order-execution-keeper-service/src/executor.ts` — extractExpectedNonce, sequential execution, nonce recovery
-- `/Users/ken/Projects/0xM/0xMarkets-Interface/.planning/PROJECT.md` — single wallet decision, liquidation keeper pending verification, nonce management notes
-- `/Users/ken/Projects/0xM/0xMarkets-Interface/.planning/phases/24-contract-bug-fixes/24-01-PLAN.md` — full contract redeploy context, interface listing, known addresses
+### Primary (HIGH confidence -- official documentation and verified issues)
+- [Vercel KB: Serverless Functions do not support WebSocket](https://vercel.com/kb/guide/do-vercel-serverless-functions-support-websocket-connections) -- Vercel's official statement
+- [Nginx WebSocket proxy documentation](https://nginx.org/en/docs/http/websocket.html) -- official proxy_read_timeout default of 60s
+- [ws library: memory leak in weak network environments](https://github.com/websockets/ws/issues/1830) -- confirmed bufferedAmount accumulation
+- [Node.js backpressure in streams](https://nodejs.org/en/learn/modules/backpressuring-in-streams) -- official Node.js documentation
+- [Pyth Hermes documentation](https://docs.pyth.network/price-feeds/core/how-pyth-works/hermes) -- SSE streaming, 24h auto-disconnect
+
+### Secondary (MEDIUM confidence -- well-sourced technical analysis)
+- [WebSocket backpressure analysis](https://skylinecodes.substack.com/p/backpressure-in-websocket-streams) -- buffering layer breakdown
+- [WebSocket heartbeat/ping-pong implementation](https://oneuptime.com/blog/post/2026-01-27-websocket-heartbeat/view) -- 20-30s interval recommendation
+- [WebSockets in production with Node.js](https://medium.com/voodoo-engineering/websockets-on-production-with-node-js-bdc82d07bb9f) -- silent disconnect patterns
+- [Wolt: From polling to WebSockets](https://careers.wolt.com/en/blog/engineering/from-polling-to-websockets-improving-order-tracking-user-experience) -- race condition during migration, timestamp-based ordering
+
+### Codebase Analysis (HIGH confidence -- direct reading)
+- `keeper-service/src/core/candleCollector.ts` -- 2s HTTP polling, in-memory candle building, floorToMinute logic
+- `keeper-service/src/server/controllers/pricesController.ts` -- HTTP ticker endpoint, normalizePythPrice, HermesClient usage
+- `keeper-service/src/core/pythLazerOracle.ts` -- existing Pyth Lazer WebSocket, binary EVM format, 200ms channel
+- `keeper-service/src/server/httpServer.ts` -- Express on port 37017, CORS middleware, health endpoint
+- `src/domain/synthetics/tokens/useTokenRecentPricesData.ts` -- SWR with 1s refreshInterval, publish_time available
+- `src/lib/timeConstants.ts` -- PRICES_UPDATE_INTERVAL = 1000ms
+- `src/lib/oracleKeeperFetcher/oracleKeeperFetcher.ts` -- URL routing, fallback logic
 
 ---
-*Pitfalls research for: v1.7 Liquidation Readiness (contract redeployment + liquidation keeper)*
-*Researched: 2026-02-27*
+*Pitfalls research for: v1.12 WebSocket Price Streaming*
+*Researched: 2026-03-05*

--- a/.planning/research/STACK.md
+++ b/.planning/research/STACK.md
@@ -1,332 +1,272 @@
-# Technology Stack: v1.7 Liquidation Readiness
+# Technology Stack: v1.12 WebSocket Price Streaming
 
-**Project:** 0xMarkets keeper-service + 0xmarkets_contract
-**Researched:** 2026-02-27
+**Project:** 0xMarkets keeper-service + 0xMarkets-Interface
+**Researched:** 2026-03-05
 **Overall Confidence:** HIGH
 
 ## Context
 
-v1.7 is an additive milestone on top of a fully operational system. The contracts repo uses Hardhat + Foundry. The keeper-service uses TypeScript, Prisma, and PostgreSQL with a pipeline of scanner → riskEngine → executor. This document covers only NEW stack additions/changes needed for the three work streams:
+v1.12 replaces HTTP polling with WebSocket streaming at two boundaries:
 
-1. **Contract bug fix** — guard `triggerPrice=0` in OrderHandler for reversed markets, redeploy to Base Sepolia
-2. **Liquidation verification** — confirm the existing scanner → riskEngine → executor pipeline works on Base Sepolia
-3. **Liquidation performance** — optimize scanning (batched multicall), risk assessment, and execution latency
+1. **Pyth Hermes --> Keeper:** Replace 2s HTTP polling in `candleCollector.ts` with Hermes SSE streaming via `getPriceUpdatesStream()`
+2. **Keeper --> Frontend:** Replace 1s HTTP polling of `/prices/tickers` and `/prices/candles` with a WebSocket server on the keeper and WebSocket client on the frontend
+3. **TradingView integration:** Replace 1s `PauseableInterval` polling in `DataFeed.subscribeBars()` with real-time bar updates pushed via the keeper WebSocket
 
 ## Existing Stack (Do Not Re-research)
 
-Everything in the previous STACK.md (v1.5 Minimal Keeper Rewrite) applies to the order-execution-keeper-service and remains unchanged. The keeper-service (liquidation keeper, port 37017) uses:
-
-| Technology | Version | Role |
-|------------|---------|------|
-| TypeScript | ^5.9.3 | Language |
-| Node.js | 22 (Docker: node:22-slim) | Runtime |
-| viem | ^2.40.3 | Ethereum client |
-| @prisma/client | ^5.22.0 | Database ORM |
-| prisma | ^5.22.0 | Migrations + codegen |
-| @pythnetwork/pyth-lazer-sdk | ^5.2.0 | Oracle WebSocket |
-| @pythnetwork/hermes-client | ^2.1.0 | Oracle HTTP fallback |
-| express | ^5.1.0 | HTTP server |
-| pino | ^10.3.1 | Structured logging |
-| dotenv | ^17.2.3 | Env config |
-| vitest | ^4.0.16 | Test runner |
-| ts-node + nodemon | dev runners | Dev watch |
-
-The contracts repo uses Hardhat 2.x (^2.22.8) with hardhat-deploy, hardhat-foundry, Foundry forge, and Solidity 0.8.24.
+| Technology | Version | Service | Role |
+|------------|---------|---------|------|
+| Express | ^5.1.0 | keeper-service | HTTP server |
+| @pythnetwork/hermes-client | ^2.1.0 | keeper-service | Pyth price fetching (HTTP + SSE) |
+| @pythnetwork/pyth-lazer-sdk | ^5.2.0 | keeper-service | Oracle signing (WS, separate concern) |
+| Prisma | ^5.22.0 | keeper-service | Candle persistence |
+| pino | ^10.3.1 | keeper-service | Logging |
+| React 18 + Vite 5 | -- | frontend | UI framework |
+| SWR | 2.3.3 | frontend | Data fetching (current polling) |
+| TradingView charting_library | -- | frontend | Charts |
 
 ---
 
-## Work Stream 1: Contract Bug Fix and Redeploy
+## New Stack Additions
 
-### What Exists
+### Keeper-side: `ws` (WebSocket Server)
 
-The `0xmarkets_contract` repo already has a full Hardhat + Foundry dual-toolchain setup:
+| Technology | Version | Purpose | Why |
+|------------|---------|---------|-----|
+| ws | ^8.19.0 | WebSocket server for broadcasting prices to frontend clients | Standard Node.js WebSocket library. Zero dependencies. Attaches to existing Express HTTP server (shares port 37017). No need for Socket.IO -- we need simple broadcast, not rooms/namespaces/fallback transports. |
+| @types/ws | ^8.5.14 | TypeScript types for ws | Required for TypeScript compilation. |
 
-- **Hardhat** `^2.22.8` with `hardhat-deploy ^0.11.25`, `@nomicfoundation/hardhat-foundry ^1.1.1`, `@nomicfoundation/hardhat-verify ^2.0.11`
-- **Foundry** (`forge`) via `lib/forge-std` 1.12.0 — available for fast local tests
-- **Solidity** 0.8.24 with optimizer enabled (runs: 10)
-- **Network config** for `baseSepolia` already present in `hardhat.config.ts`
-- **Deploy scripts** exist but are in `deploy/` directory (not found as TypeScript — likely JavaScript or a convention not committed)
+**Why `ws` and not alternatives:**
 
-### What Is Needed
+| Alternative | Why Not |
+|-------------|---------|
+| Socket.IO | Adds 300KB+ bundle, abstractions for rooms/namespaces/acknowledgements we don't need. We broadcast one-way price data to all connected clients -- raw WebSocket is sufficient. |
+| uWebSockets.js | Higher performance but C++ binding, harder to install in Docker, overkill for <100 concurrent connections on testnet. |
+| express-ws | Unmaintained (last publish 2020), wraps `ws` anyway. Better to use `ws` directly for control. |
+| SSE (Server-Sent Events) | One-directional like our use case, but browser EventSource API has no built-in reconnection backoff control, and we may want bidirectional later (subscribe to specific markets). WebSocket is more future-proof. |
 
-**Nothing new to install.** The fix is surgical Solidity editing inside the existing repo, then redeploying with the existing Hardhat pipeline.
-
-#### Solidity Fix Pattern
-
-The bug is a division-by-zero in `OrderHandler.sol` when `triggerPrice=0` for reversed markets (JPY/USD). The fix is a guard:
-
-```solidity
-// In OrderHandler._setExactOrderPrice() or equivalent:
-// BEFORE (causes division-by-zero):
-uint256 price = WeiPerUnit * WeiPerUnit / triggerPrice; // reversed market
-
-// AFTER (guard against zero):
-require(triggerPrice > 0, "OrderHandler: triggerPrice cannot be zero for reversed market");
-// OR return early / use a sentinel:
-if (triggerPrice == 0) revert Errors.EmptyTriggerPrice();
-```
-
-The exact location in OrderHandler.sol needs to be confirmed when editing. Search for `triggerPrice` and the reversal logic to find the division site.
-
-#### Redeploy Command (existing toolchain)
+**Installation (keeper-service):**
 
 ```bash
-# From 0xmarkets_contract/
-ACCOUNT_KEY=<deployer_pk> npx hardhat deploy --network baseSepolia --tags OrderHandler
-# Or if using specific deploy script:
-ACCOUNT_KEY=<deployer_pk> npx hardhat run scripts/deployOrderHandler.ts --network baseSepolia
+cd keeper-service
+pnpm add ws
+pnpm add -D @types/ws
 ```
 
-**After redeploy:** Update `ORDER_HANDLER_ADDRESS` in ALL services (order-execution-keeper-service, keeper-service, interface, squid). See `.claude/contract-address-update-guide.md`.
+### Keeper-side: Hermes SSE Streaming (Already Installed)
 
-#### Verification (existing toolchain)
+No new package needed. `@pythnetwork/hermes-client@2.1.0` already exposes `getPriceUpdatesStream()` which returns an `EventSource` (SSE client). The `eventsource@^3.0.5` package is a transitive dependency of hermes-client, already resolved in the lockfile.
 
-```bash
-# Verify on Basescan using already-configured hardhat-verify
-BASESCAN_API_KEY=<key> npx hardhat verify --network baseSepolia <NEW_ADDRESS> <constructor_args>
-```
-
-**Confidence: HIGH** — No new tooling needed. The existing Hardhat pipeline handles compile, deploy, and verify.
-
----
-
-## Work Stream 2: Liquidation Verification
-
-### What Exists
-
-The keeper-service has a full test infrastructure but most tests are stubs. The actual pipeline integration tests are in `src/test/testnet/integration.test.ts` (skipped unless `TEST_ENV=testnet`) and E2E tests in `src/test/e2e/` (use mock contracts, not real Base Sepolia).
-
-The existing scanner already does the critical work: auto-discovers accounts from DataStore POSITION_LIST, fetches positions, calls `Reader.isPositionLiquidatable()`, and triggers executor if liquidatable. The executor uses Lazer oracle cache (via `getPythLazerOracle()`) and calls `LiquidationHandler.executeLiquidation()`.
-
-**Critical observation:** The `riskEngine.ts` is NOT called by `scanner.ts`. The scanner calls `Reader.isPositionLiquidatable()` on-chain directly. The `riskEngine.ts` is a standalone module that computes risk off-chain using its own formula (collateral vs MMR). This is a structural inconsistency — the scanner bypasses the riskEngine entirely and delegates liquidatability determination to the contract.
-
-### What Is Needed for Verification
-
-**No new dependencies.** Verification is about running the existing pipeline against real Base Sepolia testnet data.
-
-#### Verification Test Pattern
-
-The `src/test/testnet/integration.test.ts` scaffolding exists but the test bodies are stub assertions. To verify end-to-end:
-
-1. Set `TEST_ENV=testnet` environment variable
-2. Provide `TEST_RPC_URL`, `TEST_PRIVATE_KEY`, real contract addresses
-3. Fill in the existing test stubs with actual assertions
-
-The test pattern already in place:
+**API (verified from hermes-client type declarations):**
 
 ```typescript
-// src/test/testnet/integration.test.ts
-// Already has describe.skipIf(!isTestnetMode())
-// Already imports getTestRPCClient(), getTestDatabase()
-// Just needs real assertions replacing the stub expects
-```
-
-**What to write (not new dependencies):**
-
-```typescript
-it('should fetch positions from real contracts', async () => {
-  const positionFetcher = new PositionFetcher(84532);
-  const positions = await positionFetcher.discoverAccountsWithPositions();
-  // verify it runs without throwing, returns array
-  expect(Array.isArray(positions)).toBe(true);
-});
-
-it('should complete scan cycle without throwing', async () => {
-  await scanner.scan(); // runs full pipeline
-  // verify health state updated
-  expect(healthState.lastScanAt).toBeTruthy();
-});
-```
-
-**Confidence: HIGH** — No new packages needed. Tests run with `vitest ^4.0.16` already installed.
-
----
-
-## Work Stream 3: Liquidation Performance Optimization
-
-### Performance Problem Analysis
-
-The current position discovery path (`discoverAccountsWithPositions()`) makes N+1 individual RPC calls:
-
-1. One call to get `totalCount` from DataStore
-2. One batch call to get position keys (100 at a time)
-3. One individual `getPosition()` call **per position key** to extract the account
-
-Then for each discovered account, `fetchAccountPositions()` loops with individual `getAccountPositions()` calls. For M accounts and P positions total, this is O(P) serial RPC calls, each costing ~100-300ms on Base Sepolia testnet.
-
-### New Tool: viem Multicall
-
-**Already available in viem `^2.40.3`.** No new installation required.
-
-`viem`'s `publicClient.multicall()` batches multiple `readContract` calls into a single RPC round-trip using the Multicall3 contract deployed on all major chains including Base Sepolia.
-
-```typescript
-// BEFORE: N serial calls
-for (const positionKey of positionKeys) {
-  const position = await publicClient.readContract({
-    address: READER_ADDRESS,
-    abi: READER_ABI,
-    functionName: "getPosition",
-    args: [DATA_STORE_ADDRESS, positionKey],
-  });
-}
-
-// AFTER: 1 multicall
-const results = await publicClient.multicall({
-  contracts: positionKeys.map(key => ({
-    address: READER_ADDRESS,
-    abi: READER_ABI,
-    functionName: "getPosition",
-    args: [DATA_STORE_ADDRESS, key],
-  })),
-  allowFailure: true, // don't abort if one position errors
-});
-// results is { status: 'success' | 'failure', result: PositionProps }[]
-```
-
-**Multicall3 address on Base Sepolia:** `0xcA11bde05977b3631167028862bE2a173976CA11` (same across all EVM chains — standard deployment). viem uses this automatically when chain config includes it, which Base Sepolia does.
-
-**Confidence: HIGH** — viem multicall is documented, stable since viem 1.x, and Base Sepolia has Multicall3 deployed.
-
-### Supporting: Parallel Account Fetching
-
-After account discovery, `fetchPositionsFromAccounts()` currently loops serially. Replace with `Promise.all()`:
-
-```typescript
-// BEFORE: serial per-account
-for (const account of accounts) {
-  const positions = await positionFetcher.fetchAccountPositions(account);
-}
-
-// AFTER: parallel fetch (all accounts simultaneously)
-const allResults = await Promise.all(
-  accounts.map(acc => positionFetcher.fetchAccountPositions(acc).catch(() => []))
+// Already available -- NO new install
+const hermesClient = new HermesClient("https://hermes.pyth.network");
+const eventSource: EventSource = await hermesClient.getPriceUpdatesStream(
+  Object.values(PYTH_PRICE_FEED_IDS), // string[] of hex feed IDs
+  { parsed: true }                      // get structured price data, not just binary
 );
-const allPositions = allResults.flat();
+
+eventSource.onmessage = (event) => {
+  const priceUpdate: PriceUpdate = JSON.parse(event.data);
+  // priceUpdate.parsed contains array of { id, price: { price, expo, ... }, ... }
+};
 ```
 
-No new dependencies — this is a code pattern change only.
+**Key behavior:** The Hermes SSE connection auto-closes after 24 hours. Must implement reconnection logic. This is NOT a limitation of the library -- it is Hermes server-side policy to prevent resource leaks.
 
-### Timing Instrumentation
+### Frontend: Native WebSocket (No New Package)
 
-The existing `pino ^10.3.1` logger supports high-resolution timestamps via `Date.now()` or `performance.now()`. No new tooling needed.
+The browser `WebSocket` API is sufficient. No library needed.
 
-Pattern already used in order-execution-keeper-service (and copied here):
+| Alternative | Why Not |
+|-------------|---------|
+| socket.io-client | Would require Socket.IO on server side. Adds bundle weight for features we don't use. |
+| reconnecting-websocket | Nice convenience, but trivial to implement reconnection in ~20 lines. Not worth a dependency. |
+| @tanstack/react-query ws adapter | Doesn't exist as a first-party adapter. SWR/react-query are for request-response, not streaming. |
+
+**Pattern for frontend:**
 
 ```typescript
-const t0 = performance.now();
-const positions = await discoverAccountsWithPositions();
-log.info({ durationMs: Math.round(performance.now() - t0), count: positions.length }, "discovery complete");
+// Custom hook: useWebSocketPrices()
+const ws = new WebSocket(`wss://${keeperHost}/ws/prices`);
+ws.onmessage = (event) => {
+  const data = JSON.parse(event.data);
+  // Update React state / SWR cache
+};
 ```
 
-`performance` is available in Node 22 without any import.
+---
+
+## Integration Architecture
+
+### 1. Hermes SSE --> Keeper (replaces candleCollector polling)
+
+**Current:** `candleCollector.ts` calls `hermesClient.getLatestPriceUpdates()` every 2s via `setInterval`.
+
+**New:** `candleCollector.ts` calls `hermesClient.getPriceUpdatesStream()` once at startup. Each SSE message triggers candle update logic (same `tick()` body, but event-driven instead of polled). Reconnection on close/error with exponential backoff.
+
+**Integration point:** The `currentCandles` Map and Prisma upsert logic stay identical. Only the trigger mechanism changes from `setInterval(tick, 2000)` to `eventSource.onmessage`.
+
+### 2. Keeper WebSocket Server --> Frontend (replaces /prices/tickers polling)
+
+**Current:** Frontend polls `GET /prices/tickers` every 1s via SWR. Keeper reads from Pyth Lazer cache + currentCandles map.
+
+**New:** Keeper creates a `WebSocketServer` attached to the existing Express HTTP server (sharing port 37017). On each Hermes SSE price update, keeper broadcasts a JSON message to all connected WebSocket clients containing ticker data in the same format as `/prices/tickers`.
+
+**ws attaches to Express HTTP server (shares port):**
+
+```typescript
+import { WebSocketServer } from "ws";
+import { createHttpServer } from "./httpServer.js";
+
+const server = createHttpServer(); // returns http.Server from app.listen()
+const wss = new WebSocketServer({ server, path: "/ws/prices" });
+
+wss.on("connection", (ws) => {
+  // Send initial snapshot
+  ws.send(JSON.stringify({ type: "tickers", data: getCurrentTickers() }));
+  ws.send(JSON.stringify({ type: "candles", data: getRecentCandles() }));
+});
+
+// On each Hermes SSE update:
+function broadcastTickers(tickers: TickerData[]) {
+  const msg = JSON.stringify({ type: "tickers", data: tickers });
+  for (const client of wss.clients) {
+    if (client.readyState === WebSocket.OPEN) {
+      client.send(msg);
+    }
+  }
+}
+```
+
+**Key:** `createHttpServer()` currently returns the Express app's `server` from `app.listen()`. The `ws` library's `WebSocketServer` handles the HTTP Upgrade handshake when `{ server }` is passed. No additional Express middleware needed.
+
+### 3. TradingView Real-time Bars (replaces PauseableInterval polling)
+
+**Current:** `DataFeed.subscribeBars()` creates a `PauseableInterval` that calls `this.fetchCandles()` (HTTP to `/prices/candles`) every 1s.
+
+**New:** `DataFeed.subscribeBars()` listens to the WebSocket connection for candle updates. The keeper pushes candle bar data on each price update. The `onTick` callback fires immediately on receipt instead of after a 1s poll delay.
+
+**Integration point:** The existing `subscribeBars` callback signature (`onTick: SubscribeBarsCallback`) remains identical. Only the data source changes from HTTP poll to WebSocket message.
 
 ---
 
-## Complete Stack Delta for v1.7
+## Message Protocol (Keeper --> Frontend WebSocket)
 
-### keeper-service: No New Dependencies
+Use simple JSON messages with a `type` discriminator:
 
-| Package | Status | Reason |
-|---------|--------|--------|
-| viem multicall | Existing | Already in viem ^2.40.3 |
-| vitest | Existing | Already devDependency ^4.0.16 |
-| pino timing | Existing | Built-in with performance.now() |
+```typescript
+// Ticker update (replaces /prices/tickers polling)
+{
+  type: "tickers",
+  data: [
+    { tokenSymbol: "WETH", minPrice: "...", maxPrice: "...", oracleDecimals: 18, tokenAddress: "0x...", updatedAt: 1709654400 }
+  ]
+}
 
-**No `pnpm add` commands needed for keeper-service.**
+// Candle update (replaces /prices/candles polling)
+{
+  type: "candle",
+  data: {
+    tokenSymbol: "WETH",
+    time: 1709654400,
+    open: 3245.50,
+    high: 3246.20,
+    low: 3245.10,
+    close: 3245.80
+  }
+}
+```
 
-### 0xmarkets_contract: No New Dependencies
-
-| Package | Status | Reason |
-|---------|--------|--------|
-| hardhat ^2.22.8 | Existing | Already installed |
-| hardhat-deploy | Existing | Already installed |
-| @nomicfoundation/hardhat-verify | Existing | Already installed |
-| Foundry forge | Existing | Already available via foundry.toml |
-
-**No `yarn add` commands needed for contracts repo.**
-
----
-
-## Critical Integration Points
-
-### 1. Pyth Lazer Oracle Cache in Scanner
-
-The scanner calls `getStoredPrice()` from the `PythLazerFeedProvider` contract (on-chain stored prices) to get market prices for liquidatability checks. The order-execution-keeper pushes Lazer prices every ~5s. If the order-execution-keeper is down or stale, `getStoredPrice()` returns `ok: false` or a stale timestamp, and the scanner will skip all position checks.
-
-**Dependency:** Liquidation verification requires the order-execution-keeper to be running and pushing prices.
-
-### 2. Prisma Schema / Database
-
-The store uses Prisma 5.22.0 with PostgreSQL. Before running verification tests against testnet, the database must be migrated. The Docker Compose setup on DigitalOcean includes the postgres service and auto-runs `prisma migrate deploy` on startup.
-
-**For local verification:** `cd keeper-service && pnpm db:migrate` requires a local PostgreSQL or the DO database URL.
-
-### 3. Position Discovery Bottleneck in `discoverAccountsWithPositions()`
-
-The current implementation fetches individual positions to extract account addresses. This is the primary optimization target: replace with multicall to batch N positions into one RPC call. The positions stored in DataStore's POSITION_LIST are bytes32 keys — each key encodes `keccak256(abi.encode(account, market, collateralToken, isLong))`. The contract does NOT expose the account from a position key without reading the full position struct.
-
-Therefore: multicall on `getPosition()` for all keys is the correct batching approach (one RPC round-trip instead of N serial calls).
-
-### 4. Contract Addresses After Redeploy
-
-After OrderHandler redeploy, `keeper-service`'s `ORDER_HANDLER_ADDRESS` env var must be updated. Currently keeper-service only has `LIQUIDATION_HANDLER_ADDRESS` — it does not call OrderHandler directly. But the E2E test suite in `order-execution-keeper-service` does. Update checklist per `.claude/contract-address-update-guide.md`.
+**Why not Protocol Buffers / MessagePack:** JSON is fine at this scale (7 tokens, <1KB per message). The overhead of a binary protocol is not justified when messages are tiny and connection count is low. HTTP API responses are already JSON -- consistency reduces integration friction.
 
 ---
 
 ## What NOT to Add
 
-### Do NOT add a separate multicall library
+### Do NOT add Socket.IO
 
-`viem` already exposes `publicClient.multicall()` that uses Multicall3 under the hood. Do not add `ethers-multicall`, `multicall.js`, or similar. Zero value, adds dependency weight.
+Socket.IO adds ~300KB to the frontend bundle and requires `socket.io` on the server. It provides rooms, namespaces, acknowledgments, and HTTP long-polling fallback -- none of which we need. We broadcast price data one-way to all connected clients. Native WebSocket handles this.
 
-### Do NOT add a task queue (Bull, BullMQ, etc.)
+### Do NOT add a message queue (Redis Pub/Sub, NATS, etc.)
 
-The scanner already runs on a simple `setInterval` loop with an `scanRunning` guard to prevent overlap. Performance gains from multicall and parallel fetching will make each scan cycle faster — no queue needed at this scale.
+Single keeper server broadcasting to frontend clients. No multi-instance coordination needed. A message queue adds operational complexity (another service to run in Docker Compose) for zero benefit at this scale.
 
-### Do NOT add Foundry for testing keeper TypeScript
+### Do NOT add GraphQL Subscriptions
 
-Foundry is for Solidity contract testing, not keeper TypeScript. The existing vitest setup is correct for keeper unit/integration tests.
+The data model is simple: ticker prices and candle bars. GraphQL subscriptions would require Apollo Server, subscription transport, and schema definitions for what amounts to two message types. Massive overhead.
 
-### Do NOT add a profiling daemon (clinic.js, 0x flame)
+### Do NOT replace SWR entirely
 
-Performance gains here come from reducing RPC round-trips via multicall, not from CPU profiling. The bottleneck is network latency, measurable with `performance.now()` already available.
+SWR still handles non-streaming data (candle history, 24h prices, incentives, APY). Only the real-time ticker/candle feeds move to WebSocket. Keep SWR for request-response patterns; add WebSocket alongside it for streaming.
 
-### Do NOT upgrade Prisma from ^5.22.0 to ^7.x
+### Do NOT add reconnecting-websocket on frontend
 
-The order-execution-keeper-service removed Prisma. The keeper-service still uses it. Prisma 7.x has a new adapter-based API that would require schema and query changes. Prisma 5.22.0 is stable and handles all required queries. Upgrade is out of scope.
+Reconnection with exponential backoff is ~20 lines of code. Adding a dependency for this is unnecessary when the reconnection logic is trivial and we want full control over behavior (e.g., showing a "reconnecting" banner).
 
-### Do NOT add Hardhat Ignition for contract deployment
+### Do NOT upgrade @pythnetwork/hermes-client
 
-The contracts repo uses `hardhat-deploy`, not Hardhat Ignition. Ignition is the newer deployment framework (introduced in Hardhat 2.22+) but the existing `hardhat-deploy` scripts are proven and sufficient for a single-contract patch deploy. Switching deployment frameworks for a bug fix is unnecessary risk.
+Version 2.1.0 already has `getPriceUpdatesStream()` with full SSE support. No need to chase a newer version.
 
-### Do NOT upgrade hardhat to ^2.24 or ethers to v6
+### Do NOT use Pyth Lazer for candle data
 
-The contracts repo uses hardhat ^2.22.8 + ethers ^5.7.2. These are pinned and working. The Hardhat ecosystem has some breaking changes between ethers v5 and v6. Do not touch the contracts toolchain version for a Solidity fix.
+Pyth Lazer (via pyth-lazer-sdk) is for oracle price signing -- it delivers binary EVM payloads for on-chain use. Pyth Hermes provides parsed price data suitable for candle construction. These are different products with different purposes. Continue using Hermes for candles and Lazer for oracle signing.
 
 ---
 
-## Alternatives Considered
+## Complete Stack Delta for v1.12
 
-| Category | Recommended | Alternative | Why Not |
-|----------|-------------|-------------|---------|
-| Batch RPC | viem multicall (built-in) | ethcall / multicall.js | Already in viem, zero extra dep |
-| Contract profiling | Hardhat gas reporter (already installed) | Tenderly DevNets, Foundry --gas-report | Already available, sufficient for testnet |
-| Position discovery | Multicall batch on getPosition() | Parse position keys off-chain | Keys are opaque hashes, cannot decode account without contract call |
-| Liquidation test | Vitest testnet mode (existing) | Hardhat fork of Base Sepolia | Fork adds complexity; real testnet is sufficient for verification |
-| Deploy verification | hardhat-verify (existing) | Manual Basescan upload | hardhat-verify already configured and working |
+### keeper-service: 1 New Dependency
+
+```bash
+cd keeper-service
+pnpm add ws
+pnpm add -D @types/ws
+```
+
+| Package | Version | Status | Purpose |
+|---------|---------|--------|---------|
+| ws | ^8.19.0 | NEW | WebSocket server for broadcasting prices to frontend |
+| @types/ws | ^8.5.14 | NEW (dev) | TypeScript types |
+| @pythnetwork/hermes-client | ^2.1.0 | EXISTING | Use `getPriceUpdatesStream()` instead of `getLatestPriceUpdates()` |
+
+### 0xMarkets-Interface (frontend): 0 New Dependencies
+
+| Technology | Status | Purpose |
+|------------|--------|---------|
+| Native WebSocket API | BUILT-IN | Connect to keeper WebSocket server |
+| SWR 2.3.3 | EXISTING | Continues handling non-streaming data |
+| TradingView charting_library | EXISTING | `subscribeBars` callback wired to WebSocket data |
+
+**No `yarn add` commands needed for the frontend.**
+
+---
+
+## Keeper HTTP Endpoints: Keep for Fallback
+
+Do NOT remove the existing HTTP endpoints (`/prices/tickers`, `/prices/candles`). Keep them as:
+
+1. **Fallback** when WebSocket connection fails (frontend can degrade to polling)
+2. **Health monitoring** (BetterStack pings HTTP endpoints)
+3. **Initial data load** (historical candles are request-response, not streaming)
+4. **Debugging** (curl-friendly for manual inspection)
+
+The WebSocket channel is an addition, not a replacement.
 
 ---
 
 ## Sources
 
-- Existing codebase: `keeper-service/package.json` — confirmed Prisma 5.22.0, vitest 4.0.16, viem 2.40.3
-- Existing codebase: `keeper-service/src/core/scanner.ts` — confirmed scanner calls Reader.isPositionLiquidatable() directly, bypasses riskEngine.ts
-- Existing codebase: `keeper-service/src/core/positionFetcher.ts` — confirmed N+1 serial RPC pattern in discoverAccountsWithPositions()
-- Existing codebase: `keeper-service/src/core/executor.ts` — confirmed Lazer oracle cache dependency via getPythLazerOracle()
-- Existing codebase: `0xmarkets_contract/package.json` — confirmed hardhat ^2.22.8, hardhat-deploy ^0.11.25, hardhat-verify ^2.0.11
-- Existing codebase: `0xmarkets_contract/hardhat.config.ts` — confirmed baseSepolia network config, Solidity 0.8.24
-- Existing codebase: `0xmarkets_contract/foundry.toml` — confirmed forge-std 1.12.0 available
-- Existing codebase: `keeper-service/src/test/testnet/integration.test.ts` — confirmed testnet test scaffolding exists with stub assertions
-- viem documentation: `publicClient.multicall()` stable API, Multicall3 auto-detected on Base Sepolia (chainId 84532)
-- Multicall3: deployed at `0xcA11bde05977b3631167028862bE2a173976CA11` on all major EVM chains including Base Sepolia (confidence: HIGH — standard deployment address)
+- Existing codebase: `keeper-service/package.json` -- confirmed @pythnetwork/hermes-client@^2.1.0, express@^5.1.0 (HIGH confidence)
+- Existing codebase: `keeper-service/node_modules/@pythnetwork/hermes-client/dist/esm/hermes-client.d.ts` -- confirmed `getPriceUpdatesStream()` returns `Promise<EventSource>` with parsed option (HIGH confidence)
+- Existing codebase: `keeper-service/node_modules/@pythnetwork/hermes-client/package.json` -- confirmed `eventsource@^3.0.5` transitive dependency (HIGH confidence)
+- Existing codebase: `keeper-service/src/core/candleCollector.ts` -- confirmed 2s polling via setInterval + getLatestPriceUpdates (HIGH confidence)
+- Existing codebase: `src/lib/oracleKeeperFetcher/oracleKeeperFetcher.ts` -- confirmed HTTP fetch to /prices/tickers and /prices/candles (HIGH confidence)
+- Existing codebase: `src/domain/tradingview/DataFeed.ts` -- confirmed PauseableInterval polling in subscribeBars at 1s (HIGH confidence)
+- Existing codebase: `src/domain/synthetics/tokens/useTokenRecentPricesData.ts` -- confirmed SWR polling at PRICES_UPDATE_INTERVAL (1000ms) (HIGH confidence)
+- [ws npm package](https://www.npmjs.com/package/ws) -- v8.19.0 latest, zero dependencies (HIGH confidence)
+- [ws GitHub releases](https://github.com/websockets/ws/releases) -- v8.19.0 released Jan 2025 (HIGH confidence)
+- [Pyth Hermes SSE documentation](https://docs.pyth.network/price-feeds/core/fetch-price-updates) -- /v2/updates/price/stream endpoint, 24h auto-close (MEDIUM confidence -- verified via docs)
+- [Pyth Hermes architecture](https://docs.pyth.network/price-feeds/core/how-pyth-works/hermes) -- SSE streaming overview (MEDIUM confidence)
+- [@pythnetwork/hermes-client GitHub](https://github.com/pyth-network/pyth-crosschain/tree/main/apps/hermes/client/js) -- getPriceUpdatesStream usage example (MEDIUM confidence)

--- a/.planning/research/SUMMARY.md
+++ b/.planning/research/SUMMARY.md
@@ -1,183 +1,155 @@
 # Project Research Summary
 
-**Project:** 0xMarkets v1.7 — Liquidation Readiness
-**Domain:** GMX-style perpetual futures keeper service — contract bug fix + liquidation pipeline verification and optimization
-**Researched:** 2026-02-27
+**Project:** v1.12 WebSocket Price Streaming
+**Domain:** Real-time price streaming for perpetual futures trading interface
+**Researched:** 2026-03-05
 **Confidence:** HIGH
 
 ## Executive Summary
 
-v1.7 is a purely additive milestone on an otherwise operational system. The protocol stack (Hardhat 2.x + Foundry, TypeScript 5.x, viem 2.x, Prisma 5.x, Pyth Lazer) is fully in place and requires zero new dependencies. The work divides into three sequential, dependency-ordered streams: (1) fix a confirmed Solidity division-by-zero in `BaseOrderUtils.sol` for reversed markets (JPY/USD), redeploy `OrderHandler` and `ExchangeRouter`, and propagate addresses to all five services; (2) verify the existing liquidation pipeline end-to-end on Base Sepolia — roles, oracle freshness, a real underwater position, and DB state transitions; (3) harden reliability with deduplication guards, REVERTED status tracking, and timing instrumentation.
+This project replaces three HTTP polling loops with WebSocket-based streaming across two system boundaries: Pyth Hermes to the keeper service (SSE), and the keeper service to the frontend (WebSocket). The current architecture polls Pyth Hermes every 2 seconds for candle data and forces every frontend tab to poll the keeper every 1 second for both ticker prices and chart bars. This adds 1-3 seconds of unnecessary latency and scales poorly with multiple open tabs. The recommended approach follows a strict upstream-first build order: stream from Hermes first, then expose a WebSocket server on the keeper, then wire the frontend to consume it.
 
-The recommended approach is strict sequential ordering: contract fix first, then verification, then optimization. Reversing this order is the primary anti-pattern. If multicall batching is applied before basic pipeline verification passes, any new failure is ambiguous. The codebase has a ready-made testnet test scaffold (`src/test/testnet/integration.test.ts`) that just needs its stub assertions filled in. Using this — not a separate test harness — is the right implementation path.
+The stack delta is minimal -- one new dependency (`ws` ^8.19.0) on the keeper, zero new dependencies on the frontend. The existing `@pythnetwork/hermes-client` already supports SSE streaming via `getPriceUpdatesStream()`. The frontend uses the native browser WebSocket API. SWR continues handling non-streaming data (candle history, APY, incentives). This is a targeted infrastructure upgrade, not a rewrite.
 
-The dominant risk is not code complexity; it is integration surface. The liquidation keeper depends on the order-execution-keeper staying alive to push oracle prices on-chain. If `ORACLE_MODE` is left at the default `hermes` in docker-compose.yml, the keeper silently degrades the moment the order-execution-keeper restarts. Additionally, both keepers share a single wallet, creating a nonce race condition when a liquidation TX fires simultaneously with a deposit or order TX. For testnet verification, this is an acceptable documented risk. For production, separate wallets are mandatory. The contract redeploy also has a non-obvious trap: `ExchangeRouter` stores `OrderHandler` as an immutable constructor arg, so redeploying only `OrderHandler` silently leaves users broken while the keeper continues working.
-
----
+The primary risks are infrastructure-level: Vercel cannot proxy WebSocket connections (the frontend must connect directly to the keeper), which requires TLS termination on the DigitalOcean droplet to avoid mixed-content blocking. On the keeper side, unbounded message buffering for slow/dead clients can OOM the process and take down all keeper services (liquidations, order execution, candle collection). Both risks have well-documented mitigations and must be addressed in Phase 1 before any downstream work begins.
 
 ## Key Findings
 
 ### Recommended Stack
 
-No new dependencies are required for v1.7. The existing stack handles every work stream: viem `^2.40.3` already exposes `publicClient.multicall()` using Multicall3 (deployed at `0xcA11bde05977b3631167028862bE2a173976CA11` on Base Sepolia); vitest `^4.0.16` runs all testnet integration tests; Hardhat `^2.22.8` with `hardhat-deploy` and `hardhat-verify` handles the contract compile/deploy/verify cycle.
+The stack change is deliberately small. Only one new npm package is needed across both services.
 
 **Core technologies:**
-- **TypeScript 5.x / Node 22 (Docker: node:22-slim):** Keeper service runtime — unchanged
-- **viem `^2.40.3`:** Ethereum client with built-in multicall3 support — use `publicClient.multicall()` for batched position discovery; no extra library needed
-- **Hardhat `^2.22.8` + hardhat-deploy + Foundry forge:** Contract compile, deploy, verify — existing scripts cover the full redeploy cycle
-- **Solidity 0.8.24:** Contract language — fix targets `BaseOrderUtils.sol`; guard `sizeDeltaInTokens == 0` before the division
-- **Prisma `^5.22.0` + PostgreSQL 16:** Audit trail for liquidation candidates/executions — schema unchanged for v1.7
-- **@pythnetwork/pyth-lazer-sdk `^5.2.0`:** Oracle price cache — set `ORACLE_MODE=lazer` in keeper-service docker-compose.yml for independent oracle operation
-- **pino `^10.3.1` + `performance.now()`:** Per-stage timing instrumentation — no new tooling needed
-
-**What NOT to add:** Do not add ethers-multicall, BullMQ, clinic.js, Hardhat Ignition, or any separate profiling daemon. The bottleneck is network round-trips (RPC), not CPU, and viem already solves it.
+- `ws` ^8.19.0 (keeper): WebSocket server for broadcasting prices to frontend -- standard Node.js WS library, zero dependencies, attaches to existing Express HTTP server on port 37017
+- `@pythnetwork/hermes-client` ^2.1.0 (keeper, existing): `getPriceUpdatesStream()` returns an EventSource for SSE streaming -- replaces 2s HTTP polling with push-based price delivery
+- Native browser `WebSocket` API (frontend): No library needed -- reconnection logic is ~20 lines, avoids Socket.IO's 300KB bundle for features we do not use
+- SWR 2.3.3 (frontend, existing): Continues handling request-response data; WebSocket supplements it for streaming, does not replace it
 
 ### Expected Features
 
-The pipeline is built. v1.7 is about proving it works and hardening it.
+**Must have (table stakes):**
+- Keeper Hermes SSE streaming -- replaces 2s HTTP poll, catches price extremes between ticks
+- Keeper WebSocket endpoint -- broadcasts ticker and candle updates to all connected frontends
+- Frontend mark prices via WebSocket -- replaces 1s SWR poll, drives all price displays
+- TradingView real-time bars via WebSocket -- replaces 1s PauseableInterval poll, fixes chart staleness
+- Connection resilience with auto-reconnect and exponential backoff with jitter
+- Stale price indicator -- warning banner if prices stop arriving for >5 seconds
 
-**Must have (table stakes — blocking for this milestone):**
-- `LIQUIDATION_KEEPER` role granted to keeper wallet on `LiquidationHandler` — role may never have been verified; all executions revert without it
-- `ORDER_HANDLER_ADDRESS` + `EXCHANGE_ROUTER_ADDRESS` propagated to all five services after redeploy — stale addresses cause silent partial failures
-- Stored price freshness verified end-to-end: `order-execution-keeper` running, `getStoredPrice()` returning fresh data, scanner not skipping all positions
-- `ORACLE_MODE=lazer` set in keeper-service docker-compose.yml — default `hermes` creates silent oracle dependency on order-execution-keeper uptime
-- `Reader.isPositionLiquidatable()` returning `true` on a real underwater position, followed by `executeLiquidation` succeeding on-chain
+**Should have (differentiators):**
+- Sub-second PnL updates -- derived calculation, free once mark prices stream via WebSocket
+- More accurate candle high/low -- SSE provides more data points than 2s polling
+- Ticker snapshot on connect -- eliminates "loading prices..." gap on page load
 
-**Should have (reliability hardening):**
-- Position-key deduplication guard in executor (in-memory Map with 60s TTL) — prevents double-submission race within confirmation window
-- `REVERTED` status in confirmator (`receipt.status` check) — eliminates permanently-stuck SUBMITTED records when a TX reverts
-- Per-stage timing instrumentation with `performance.now()` — identifies bottlenecks, matches order-execution-keeper pattern from Phase 14
-
-**Defer (post-v1.7):**
-- Batched multicall for position discovery — correct optimization, negligible at testnet scale (<20 positions), matters only at 100+ open positions
-- Event-based account registry via `PositionIncrease` events — eliminates the O(N) discovery scan entirely; premature until scale is demonstrated
-- Separate wallets for keeper-service and order-execution-keeper — mandatory for production, acceptable documented risk for testnet
-- `collateralUsd` calculation fix in `positionFetcher.ts` — data quality bug in risk scores but non-blocking for execution correctness
-- Scan interval reduction to 5-10s — production requirement, unnecessary for verification
+**Defer (v2+):**
+- Multi-resolution chart streaming (current aggregation approach works)
+- Binary/protobuf encoding (JSON is fine for 6 markets on testnet)
+- Per-user position streaming (positions change infrequently, poll on trade events)
 
 ### Architecture Approach
 
-The system is two Docker containers on a DigitalOcean droplet (`142.93.203.222`) sharing a PostgreSQL 16 database and a single Ethereum wallet. The keeper-service (port 37017) runs a 30-second scan loop: discover accounts via DataStore POSITION_LIST, batch-read positions, call `Reader.isPositionLiquidatable()` on-chain, build oracle params from Pyth Lazer cache, call `LiquidationHandler.executeLiquidation()`, then watch EventLog2 for confirmation. The order-execution-keeper (port 37018) handles deposits/withdrawals/orders and — critically — pushes Pyth prices on-chain every 5 seconds, which the liquidation scanner reads back via `PythLazerFeedProvider.getStoredPrice()`. This cross-service oracle dependency is the biggest operational risk.
+The architecture follows a fan-out pattern: a single persistent SSE connection from keeper to Pyth Hermes feeds an in-memory price cache (`priceStreamCollector`), which emits events to a WebSocket broadcast server (`wsServer`), which pushes to N frontend clients. The keeper remains the single source of truth for prices -- both the WebSocket broadcast and the existing HTTP endpoints read from the same in-memory cache, eliminating divergence. The frontend maintains a single multiplexed WebSocket connection per tab with message-type discrimination (`ticker`, `candle`, `candle_update`, `ping`).
 
 **Major components:**
-1. **`scanner.ts`** — Periodic scan loop; calls `Reader.isPositionLiquidatable()` directly (authoritative on-chain check); `riskEngine.ts` is dead code, do not wire it in
-2. **`positionFetcher.ts`** — Account discovery via DataStore POSITION_LIST; current O(N) serial `getPosition()` calls per position key is the primary scale bottleneck; viem multicall fixes this
-3. **`executor.ts`** — Builds oracle params from Pyth Lazer cache; calls `LiquidationHandler.executeLiquidation()`; has a redundant `fetchAccountPositions()` call that should use data already in the snapshot; lacks nonce management (risk when sharing wallet)
-4. **`confirmator.ts`** — Watches EventLog2 via HTTP long-polling; updates execution status to MINED; needs `receipt.status` check for REVERTED handling
-5. **`order-execution-keeper oracle.ts`** — Pushes prices to `PythLazerFeedProvider` every 5s; liquidation scanner's 60s staleness guard depends on this staying alive
-6. **`BaseOrderUtils.sol`** — Bug site: `sizeDeltaInTokens == 0` for reversed markets causes division-by-zero; fix with a guard before the division
-7. **`ExchangeRouter.sol`** — Immutable `orderHandler` constructor arg; MUST be redeployed atomically with OrderHandler or users remain broken
+1. `priceStreamCollector` (keeper, new) -- single Hermes SSE connection, maintains latestTickers + currentCandles in memory, flushes completed candles to PostgreSQL
+2. `wsServer` (keeper, new) -- WebSocket server on existing HTTP server, broadcasts price/candle events, manages subscriptions and heartbeats
+3. `usePriceWebSocket` (frontend, new) -- single WS connection per tab, dispatches updates to global price store, handles reconnection
+4. `useTokenRecentPricesData` (frontend, modified) -- reads from WS-fed store with automatic HTTP polling fallback
+5. `DataFeed.subscribeBars` (frontend, modified) -- receives candle pushes via WS callback instead of PauseableInterval polling
 
 ### Critical Pitfalls
 
-1. **ExchangeRouter immutable constructor — redeploying OrderHandler alone silently fails users.** ExchangeRouter stores `orderHandler` as an `immutable` field baked into bytecode at construction time. If only `OrderHandler` is redeployed, the ExchangeRouter still routes to the old buggy contract. JPY orders continue to revert. Prevention: always deploy `ExchangeRouter` immediately after `OrderHandler` in a single atomic step; verify with `cast call <EXCHANGE_ROUTER> "orderHandler()(address)"`.
-
-2. **CONTROLLER/ROUTER_PLUGIN roles not granted to new contracts after redeploy.** The `afterDeploy` hook in `deployOrderHandler.ts` calls `grantRoleIfNotGranted` — if this throws or is skipped (gas hiccup, nonce conflict), the new contract is deployed but non-functional. Prevention: explicitly verify all three roles with `cast call <ROLE_STORE> "hasRole(bytes32,address)(bool)"` after every redeploy.
-
-3. **Stale addresses on the DO droplet live `.env` files.** Local config updates do not automatically reach `142.93.203.222`. If the droplet's `.env` is not updated and both keepers restarted, they continue calling old contracts. If old contract roles are revoked, all keeper TXs revert. Prevention: SSH to droplet immediately after local config update; restart both keeper containers.
-
-4. **`ORACLE_MODE=hermes` (default) makes liquidation oracle silently dependent on order-execution-keeper uptime.** In Hermes mode, `pythLazerOracle` is null; executor passes `"0x"` as oracle data; liquidation handler reads from on-chain stored prices that order-execution-keeper pushes. If order-execution-keeper restarts, stored prices go stale within 60s and all liquidation scans silently skip every position. Prevention: set `ORACLE_MODE=lazer` in docker-compose.yml for keeper-service.
-
-5. **Shared wallet nonce conflict between keeper-service and order-execution-keeper.** Both processes share the same `PRIVATE_KEY`. The order-execution-keeper has nonce recovery (`extractExpectedNonce`); the liquidation executor does not. A simultaneous liquidation TX + deposit TX causes one to fail with `nonce too low`. Prevention for v1.7: document as a known testnet risk. Full fix: give keeper-service its own funded wallet with `LIQUIDATION_KEEPER` role — zero code changes, just a new `.env` var and one `grantRole` transaction.
-
----
+1. **Vercel cannot proxy WebSocket** -- frontend must connect directly to keeper. Requires dedicated DNS record (`ws.0xmarkets.io`) and TLS on the DO droplet. Decide this in Phase 1 or all subsequent work is wasted.
+2. **Silent connection death without heartbeat** -- TCP connections die silently from NAT timeout, sleep/wake, mobile transitions. Server must send ping every 15-20s, terminate clients missing 2 pongs. Client must detect staleness after 10s of silence.
+3. **Dual-source race condition during migration** -- stale HTTP response overwrites fresh WS update. Gate all price updates on `publishTime` timestamp. Disable SWR polling when WS is active.
+4. **Keeper memory exhaustion from slow/dead clients** -- `ws` buffers outgoing messages unboundedly. Check `bufferedAmount` before each send, skip updates when buffer exceeds 64KB. Cap max connections. This can OOM the keeper and take down liquidations.
+5. **Mixed content blocking (HTTPS to plain WS)** -- browser blocks `ws://` from `https://` page. TLS termination (nginx + Let's Encrypt or Caddy) on DO droplet is a prerequisite for all frontend WS work.
 
 ## Implications for Roadmap
 
 Based on research, suggested phase structure:
 
-### Phase A: Contract Bug Fix
-**Rationale:** Unblocks JPY/USD liquidation testing and resolves the last known E2E test failure (1 skipped test from Phase 23). Must be first — downstream verification phases need a clean contract surface and a complete 18/18 E2E suite.
-**Delivers:** Fixed `BaseOrderUtils.sol`; redeployed `OrderHandler` + `ExchangeRouter`; updated addresses across all five services and the DO droplet; 18/18 E2E tests passing.
-**Addresses:** Table-stakes feature — contract bug fix for reversed markets.
-**Avoids:** Pitfalls 1 (ExchangeRouter immutable), 2 (role grants), 3 (address propagation to droplet), and the SKIP_HANDLER_DEPLOYMENTS env var trap.
-**Research flag:** Skip research-phase — patterns are fully documented in PITFALLS.md and the Phase 20 address audit protocol. Standard Hardhat deploy + verify cycle.
+### Phase 1: Infrastructure + Keeper Hermes SSE
 
-### Phase B: Liquidation Pipeline Verification
-**Rationale:** Before any optimization, the basic pipeline must work end-to-end. Verification is a prerequisite so that optimizations fix performance, not correctness. The testnet integration test scaffold already exists; fill in the stub assertions rather than building a new test harness.
-**Delivers:** Confirmed `LIQUIDATION_KEEPER` role on keeper wallet; confirmed oracle freshness end-to-end; a real underwater test position detected → executor submits → confirmator updates DB to EXECUTED; `ORACLE_MODE=lazer` set in docker-compose.yml.
-**Addresses:** All table-stakes features; Pitfall 12 (LIQUIDATION_KEEPER role check); Pitfall 4 (oracle independence via `ORACLE_MODE=lazer`).
-**Research flag:** Needs live testnet execution — Pitfall 11 (oracle timestamp drift in `withOraclePrices`) cannot be verified without an actual `executeLiquidation` TX on Basescan. No pre-planning research needed; the work IS the research.
+**Rationale:** Everything downstream depends on TLS infrastructure and a streaming price source. Without TLS, the frontend cannot connect. Without Hermes SSE, there is nothing to broadcast. This phase is also independently valuable -- it eliminates per-request Hermes polling even before WebSocket exists.
 
-### Phase C: Reliability Hardening
-**Rationale:** Once Phase B proves correctness, add three low-cost reliability features that eliminate edge-case failure modes. Independent of Phase A/B in terms of code but should be deployed after Phase B confirms the pipeline works.
-**Delivers:** Position-key deduplication guard in executor (in-memory Map, 60s TTL); REVERTED status handling in confirmator (`receipt.status` check); per-stage timing instrumentation (`performance.now()` at scan/check/submit/confirm boundaries).
-**Addresses:** Differentiator features from FEATURES.md; reduces DB noise from benign FAILED candidates when position closes before execution.
-**Research flag:** Skip research-phase — all three changes are small, well-understood TypeScript modifications. No external API or library research required.
+**Delivers:** TLS-terminated WebSocket-capable endpoint on DO droplet. `priceStreamCollector` replacing `candleCollector` with Hermes SSE streaming. Modified `pricesController` reading from in-memory cache instead of calling Hermes per request. All existing HTTP endpoints continue working unchanged.
 
-### Phase D: Performance Optimization (defer post-v1.7 unless scale demands it)
-**Rationale:** The O(N) serial `getPosition()` scan is a scale bottleneck, not a correctness issue. At testnet scale (5-20 open positions), it is immaterial. Defer until production scan cycle durations in logs exceed 10 seconds.
-**Delivers:** Batched `multicall` in `discoverAccountsWithPositions()` (N serial calls → 1 RPC round-trip); eliminated redundant `fetchAccountPositions()` in executor; event-based account registry via `PositionIncrease` events (longer-term).
-**Research flag:** Skip research-phase — viem multicall API is fully documented and already used in the codebase. The optimization is mechanical.
+**Addresses:** Keeper Hermes SSE (table stakes), more accurate candle high/low (differentiator)
+
+**Avoids:** Pitfall 5 (mixed content), Pitfall 1 (Vercel proxy), Pitfall 7 (candle semantics -- validate against HTTP baseline), Pitfall 9 (Lazer/Hermes naming confusion)
+
+### Phase 2: Keeper WebSocket Server
+
+**Rationale:** Server must broadcast before clients can consume. Depends on Phase 1's priceStreamCollector events.
+
+**Delivers:** `wsServer` mounted on existing HTTP server at `/ws/prices`. Broadcasts ticker + candle updates. Subscription protocol. Heartbeat/ping-pong. Backpressure handling. Testable with `wscat`.
+
+**Addresses:** Keeper WS endpoint (table stakes), ticker snapshot on connect (differentiator)
+
+**Avoids:** Pitfall 6 (port conflict -- use `noServer: true`), Pitfall 4 (memory exhaustion -- bufferedAmount check + client cap), Pitfall 2 (silent deaths -- heartbeat from day one), Pitfall 12 (format breaking changes -- define schema upfront)
+
+### Phase 3: Frontend WebSocket Integration
+
+**Rationale:** Consumer of the data. Cannot test without keeper WS server running. This is where users see the improvement.
+
+**Delivers:** `usePriceWebSocket` hook with connection management. Modified `useTokenRecentPricesData` reading from WS store. Modified `DataFeed.subscribeBars` using WS push. HTTP polling fallback. Stale price indicator. Connection status display.
+
+**Addresses:** Frontend mark prices via WS (table stakes), TradingView real-time bars (table stakes), connection resilience (table stakes), stale price indicator (table stakes), sub-second PnL updates (differentiator)
+
+**Avoids:** Pitfall 3 (race condition -- timestamp-gated updates, disable SWR when WS active), Pitfall 8 (thundering herd -- exponential backoff with jitter), Pitfall 10 (no degradation -- HTTP fallback after 5s), Pitfall 11 (background tabs -- Page Visibility API throttling)
 
 ### Phase Ordering Rationale
 
-- **A before B:** You cannot verify liquidation of JPY/USD positions if the contract panics on reversed-market orders. The E2E suite must be green before adding new verification tests — a mixed failure signal obscures which layer broke.
-- **B before C:** Reliability hardening on a pipeline that has not been proven correct adds diagnostic noise. If the dedup guard is in place but the role check fails, the failure is harder to isolate.
-- **B before D:** Multicall optimization changes the scan loop structure. If the unoptimized pipeline works, any regression from multicall is immediately attributable.
-- **C and D can overlap in development** but C ships first because it has lower risk; D should wait for demonstrated scale need.
+- **Strict upstream-first dependency chain:** Hermes SSE (data source) -> WS server (broadcaster) -> frontend client (consumer). Cannot skip or reorder.
+- **Phase 1 is independently valuable:** Even without WebSocket, switching to Hermes SSE and caching prices in memory eliminates per-request Hermes calls and improves candle accuracy. If the project stalls after Phase 1, the keeper is still better off.
+- **Infrastructure is a prerequisite, not a phase:** TLS setup is bundled into Phase 1 because Phase 3 cannot function without it. Separating infrastructure into its own phase risks it being skipped or deferred.
+- **All three phases must ship together for user-visible impact.** Phase 1 and 2 are invisible to users. Phase 3 is the payoff. Plan accordingly -- do not ship Phase 1 and leave it for weeks.
 
 ### Research Flags
 
-Phases needing deeper investigation during planning or live execution:
-- **Phase B (oracle timestamp validation):** Pitfall 11 requires live testnet execution to verify. If `executeLiquidation` reverts due to oracle timestamp drift, the fix path is not fully defined in current research. Plan to inspect the first execution TX on Basescan before declaring Phase B complete.
-- **Phase A (ExchangeRouter address checklist):** Confirm which services reference `EXCHANGE_ROUTER_ADDRESS` (vs just `ORDER_HANDLER_ADDRESS`) before executing the address update checklist. The `.claude/contract-address-update-guide.md` may predate the ExchangeRouter as a tracked address.
+Phases likely needing deeper research during planning:
+- **Phase 1 (TLS/infrastructure):** Need to verify current nginx/Caddy setup on DO droplet, DNS configuration for `ws.0xmarkets.io`, and whether the existing firewall allows WebSocket upgrade on port 37017.
+- **Phase 2 (subscription protocol):** The subscribe/unsubscribe protocol for candle channels needs exact specification -- which resolutions to support, whether to filter by symbol server-side or client-side.
 
-Phases with standard, well-documented patterns (skip `/gsd:research-phase`):
-- **Phase A (contract fix + redeploy):** Existing Hardhat pipeline; established post-deploy verification pattern from Phase 20.
-- **Phase C (reliability hardening):** Pure TypeScript additions; no external APIs or library integration.
-- **Phase D (multicall optimization):** viem multicall is stable API, already in use in the existing codebase.
-
----
+Phases with standard patterns (skip research-phase):
+- **Phase 3 (frontend WS client):** Well-documented patterns. The existing `WebsocketContextProvider.tsx` in the codebase already implements reconnect + health check for the RPC provider -- same approach applies. TradingView `subscribeBars` callback signature is unchanged.
 
 ## Confidence Assessment
 
 | Area | Confidence | Notes |
 |------|------------|-------|
-| Stack | HIGH | All dependencies confirmed from `package.json` files in both repos; no version gaps or conflicts identified |
-| Features | HIGH | All features derived from direct source code analysis of scanner, executor, confirmator, positionFetcher |
-| Architecture | HIGH | All integration points verified from actual source files; data flow traced end-to-end from scan loop to confirmator |
-| Pitfalls | HIGH | Critical pitfalls 1-4 confirmed from deploy scripts and contract source; pitfalls 5-8 confirmed from keeper-service source |
+| Stack | HIGH | All verified from existing codebase lockfiles, npm registry, and Pyth type declarations. Zero speculative dependencies. |
+| Features | HIGH | Feature set derived from direct codebase analysis of current polling patterns. Competitor analysis (Hyperliquid) confirms table stakes. |
+| Architecture | HIGH | Component boundaries follow existing codebase structure. Data flow verified against current `candleCollector.ts`, `pricesController.ts`, `DataFeed.ts`. |
+| Pitfalls | HIGH | Critical pitfalls (Vercel WS limitation, ws buffering, mixed content) sourced from official documentation and confirmed GitHub issues. |
 
 **Overall confidence:** HIGH
 
 ### Gaps to Address
 
-- **LIQUIDATION_KEEPER role status:** Unknown whether the keeper wallet currently has this role on `LiquidationHandler`. Must be checked with `cast call` before Phase B begins. If not granted, requires a `grantRole` transaction from the RoleStore admin key.
-- **Oracle timestamp drift (Pitfall 11):** The `withOraclePrices` timestamp validation is a known risk but its real-world behavior on Base Sepolia is unverified. Treat Phase B's first successful `executeLiquidation` TX as the validation event. If it reverts with an oracle error, investigate timestamp fields in the stored price struct.
-- **ExchangeRouter in the address checklist:** `.claude/contract-address-update-guide.md` may list `ORDER_HANDLER_ADDRESS` but not `EXCHANGE_ROUTER_ADDRESS` for all services. Confirm coverage before Phase A address propagation.
-- **SKIP_HANDLER_DEPLOYMENTS in CI/shell:** If anyone has this env var set in their local shell from prior work, the Phase A redeploy will silently no-op. Add an explicit `echo $SKIP_HANDLER_DEPLOYMENTS` pre-flight check to the phase plan.
-
----
+- **DO droplet TLS status:** Unknown whether nginx or Caddy is already running on the droplet. Phase 1 planning must audit current infrastructure before choosing a TLS approach.
+- **Vercel WS proxy verification:** While documentation says Vercel does not support WS, the exact behavior of the current `/api/keeper` proxy rewrite for upgrade requests should be tested empirically before committing to direct connection.
+- **Pyth Hermes SSE rate/volume:** The exact frequency of SSE events per feed is not documented precisely. Phase 1 should measure actual event rate to calibrate the batching window (100-200ms proposed).
+- **Concurrent Pyth connections:** Whether the existing Pyth Pro API key supports both a Lazer WS and a Hermes SSE connection simultaneously without rate limiting needs verification during Phase 1.
 
 ## Sources
 
-### Primary (HIGH confidence — direct codebase analysis)
-- `keeper-service/package.json` — confirmed Prisma 5.22.0, vitest 4.0.16, viem 2.40.3
-- `keeper-service/src/core/scanner.ts` — full scan loop; riskEngine confirmed bypassed; O(N) serial RPC pattern confirmed
-- `keeper-service/src/core/executor.ts` — no nonce management; double-fetch pattern; gas estimation flow
-- `keeper-service/src/core/positionFetcher.ts` — O(N) serial `getPosition()` calls; `collateralUsd` = raw token amount bug
-- `keeper-service/src/core/confirmator.ts` — HTTP long-poll; success-path only (no REVERTED handling)
-- `keeper-service/src/core/pythLazerOracle.ts` — 200ms WebSocket cache; 4-connection pool
-- `keeper-service/src/index.ts` — scan loop, ORACLE_MODE handling, startup sequence
-- `keeper-service/src/config.ts` — ORACLE_MODE defaults to "hermes"; SCAN_INTERVAL_SECONDS defaults to 30
-- `order-execution-keeper-service/src/executor.ts` — `extractExpectedNonce`, sequential execution, nonce recovery pattern
-- `order-execution-keeper-service/src/oracle.ts` — 5s background price push cadence
-- `0xmarkets_contract/package.json` — hardhat ^2.22.8, hardhat-deploy ^0.11.25, hardhat-verify ^2.0.11
-- `0xmarkets_contract/hardhat.config.ts` — baseSepolia network config, Solidity 0.8.24, optimizer runs: 10
-- `0xmarkets_contract/deploy/deployOrderHandler.ts` — `SKIP_HANDLER_DEPLOYMENTS` skip logic, afterDeploy role grants
-- `0xmarkets_contract/deploy/deployExchangeRouter.ts` — immutable OrderHandler constructor arg confirmed
-- `0xmarkets_contract/contracts/exchange/LiquidationHandler.sol` — `onlyLiquidationKeeper` modifier, `executeLiquidation` signature
-- `0xmarkets_contract/contracts/order/BaseOrderUtils.sol` — division-by-zero bug location confirmed
-- `docker-compose.yml` — two-container deployment, shared postgres, shared wallet
-- `.planning/PROJECT.md` — v1.7 milestone scope, single-wallet decision, pending liquidation verification note
+### Primary (HIGH confidence)
+- Existing codebase: `keeper-service/package.json`, `candleCollector.ts`, `pricesController.ts`, `httpServer.ts`, `pythLazerOracle.ts`
+- Existing codebase: `src/domain/tradingview/DataFeed.ts`, `useTokenRecentPricesData.ts`, `oracleKeeperFetcher.ts`, `WebsocketContextProvider.tsx`
+- `@pythnetwork/hermes-client` type declarations -- `getPriceUpdatesStream()` API verified
+- [ws npm package](https://www.npmjs.com/package/ws) v8.19.0 -- zero dependencies, upgrade handling
+- [Vercel KB: Serverless Functions do not support WebSocket](https://vercel.com/kb/guide/do-vercel-serverless-functions-support-websocket-connections)
+- [ws GitHub issue #1830](https://github.com/websockets/ws/issues/1830) -- bufferedAmount memory leak confirmed
 
 ### Secondary (MEDIUM confidence)
-- viem documentation: `publicClient.multicall()` — stable API since viem 1.x; Multicall3 auto-detected on Base Sepolia
-- Multicall3 canonical address `0xcA11bde05977b3631167028862bE2a173976CA11` — standard EVM deployment confirmed on Base Sepolia
-- `.planning/phases/14-execution-speed/14-RESEARCH.md` — Flashblocks RPC patterns, per-stage timing; patterns reused for Phase C instrumentation
+- [Pyth Hermes SSE documentation](https://docs.pyth.network/price-feeds/core/fetch-price-updates) -- 24h auto-close policy
+- [TradingView streaming implementation guide](https://www.tradingview.com/charting-library-docs/latest/tutorials/implement_datafeed_tutorial/Streaming-Implementation/)
+- [Hyperliquid WebSocket API](https://hyperliquid.gitbook.io/hyperliquid-docs/for-developers/api/websocket) -- competitor reference
+- [Nginx WebSocket proxy docs](https://nginx.org/en/docs/http/websocket.html) -- proxy_read_timeout default 60s
+- [Wolt engineering: From polling to WebSockets](https://careers.wolt.com/en/blog/engineering/from-polling-to-websockets-improving-order-tracking-user-experience) -- race condition patterns
 
 ---
-*Research completed: 2026-02-27*
-*Replaces: v1.5 SUMMARY.md (2026-02-25) — that covered the minimal keeper rewrite; this covers v1.7 liquidation readiness scope*
+*Research completed: 2026-03-05*
+*Replaces: v1.7 SUMMARY.md (2026-02-27) -- that covered liquidation readiness; this covers v1.12 WebSocket streaming scope*
 *Ready for roadmap: yes*

--- a/sdk/src/utils/tradeHistory.ts
+++ b/sdk/src/utils/tradeHistory.ts
@@ -91,7 +91,7 @@ export function createRawTradeActionTransformer(
         swapPath,
         initialCollateralAddress: initialCollateralTokenAddress,
         wrappedNativeTokenAddress: wrappedToken.address,
-        shouldUnwrapNativeToken: rawAction.shouldUnwrapNativeToken!,
+        shouldUnwrapNativeToken: rawAction.shouldUnwrapNativeToken ?? false,
         isIncrease: isIncreaseOrderType(rawAction.orderType),
       });
       const initialCollateralToken = getByKey(tokensData, initialCollateralTokenAddress);
@@ -103,15 +103,12 @@ export function createRawTradeActionTransformer(
 
       const initialCollateralDeltaAmount = bigNumberify(rawAction.initialCollateralDeltaAmount);
       const sizeDeltaUsd = bigNumberify(rawAction.sizeDeltaUsd);
-      const acceptablePrice = bigNumberify(rawAction.acceptablePrice);
-      const minOutputAmount = bigNumberify(rawAction.minOutputAmount);
+      // OrderExecuted events don't include acceptablePrice/minOutputAmount (they're creation-time params).
+      // Default to 0n — the UI already treats 0n acceptablePrice as "N/A".
+      const acceptablePrice = bigNumberify(rawAction.acceptablePrice) ?? 0n;
+      const minOutputAmount = bigNumberify(rawAction.minOutputAmount) ?? 0n;
 
-      if (
-        initialCollateralDeltaAmount === undefined ||
-        sizeDeltaUsd === undefined ||
-        acceptablePrice === undefined ||
-        minOutputAmount === undefined
-      ) {
+      if (initialCollateralDeltaAmount === undefined || sizeDeltaUsd === undefined) {
         return undefined;
       }
 
@@ -172,7 +169,7 @@ export function createRawTradeActionTransformer(
 
         transaction: rawAction.transaction,
         timestamp: rawAction.timestamp,
-        shouldUnwrapNativeToken: rawAction.shouldUnwrapNativeToken!,
+        shouldUnwrapNativeToken: rawAction.shouldUnwrapNativeToken ?? false,
         twapParams:
           rawAction.twapGroupId && rawAction.numberOfParts
             ? {

--- a/src/context/SyntheticsEvents/SyntheticsEventsProvider.tsx
+++ b/src/context/SyntheticsEvents/SyntheticsEventsProvider.tsx
@@ -203,6 +203,7 @@ export function SyntheticsEventsProvider({ children }: { children: ReactNode }) 
 
   const poolRefreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const positionsRefreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const tradeHistoryRefreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Revalidates token balances (universal -- balances shown on both pages)
   const triggerBalanceRefresh = useCallback(() => {
@@ -243,11 +244,25 @@ export function SyntheticsEventsProvider({ children }: { children: ReactNode }) 
     }, 300);
   }, [globalMutate, pathname, triggerBalanceRefresh]);
 
+  // Trade history refresh -- delayed to allow subsquid indexing
+  const triggerTradeHistoryRefresh = useCallback(() => {
+    if (tradeHistoryRefreshTimerRef.current) return;
+    tradeHistoryRefreshTimerRef.current = setTimeout(() => {
+      tradeHistoryRefreshTimerRef.current = null;
+      globalMutate(
+        (key: unknown) => Array.isArray(key) && key[1] === "useTradeHistory",
+        undefined,
+        { revalidate: true }
+      );
+    }, 2000);
+  }, [globalMutate]);
+
   // Cleanup debounce timers on unmount
   useEffect(() => {
     return () => {
       if (poolRefreshTimerRef.current) clearTimeout(poolRefreshTimerRef.current);
       if (positionsRefreshTimerRef.current) clearTimeout(positionsRefreshTimerRef.current);
+      if (tradeHistoryRefreshTimerRef.current) clearTimeout(tradeHistoryRefreshTimerRef.current);
     };
   }, []);
 
@@ -375,6 +390,7 @@ export function SyntheticsEventsProvider({ children }: { children: ReactNode }) 
       });
 
       triggerPositionsRefresh();
+      triggerTradeHistoryRefresh();
     },
 
     OrderCancelled: (eventData: EventLogData, txnParams: EventTxnParams) => {


### PR DESCRIPTION
## Summary
- **Root cause**: The subsquid indexer returns `null` for `acceptablePrice`, `minOutputAmount`, and `shouldUnwrapNativeToken` on `OrderExecuted` events (these are creation-time params not emitted at execution). The trade action transformer required all fields to be non-null and silently dropped any trade that didn't have them — meaning **every executed trade** (opens, closes, liquidations) was invisible in trade history.
- Default `acceptablePrice` and `minOutputAmount` to `0n` when null (UI already treats `0n` as "N/A")
- Fix `shouldUnwrapNativeToken` null → `false` instead of non-null assertion
- Add trade history SWR cache invalidation on `OrderExecuted` websocket events (2s delay for subsquid indexing)

## Test plan
- [x] Existing trade history tests pass (`vitest run src/components/TradeHistory`)
- [x] Verified subsquid returns data for executed trades
- [x] Verified user confirmed fix works on trade page

🤖 Generated with [Claude Code](https://claude.com/claude-code)