### PR TITLE
Squid Link Update

### DIFF
--- a/sdk/subsquid-codegen.ts
+++ b/sdk/subsquid-codegen.ts
@@ -1,7 +1,7 @@
 import { CodegenConfig } from "@graphql-codegen/cli";
 
 const config: CodegenConfig = {
-  schema: "https://7e27672d-eadb-408b-b9b8-71f30d76effd.squids.live/0xmarkets-base-sepolia@v1/api/graphql",
+  schema: "https://zero-x-markets.squids.live/0xmarkets-base-sepolia@v1/api/graphql",
   overwrite: true,
   debug: true,
   generates: {

--- a/src/config/subgraph.ts
+++ b/src/config/subgraph.ts
@@ -4,7 +4,7 @@ import { getSubgraphUrlKey } from "./localStorage";
 
 const SUBGRAPH_URLS = {
   [BASE_SEPOLIA]: {
-    subsquid: "https://7e27672d-eadb-408b-b9b8-71f30d76effd.squids.live/0xmarkets-base-sepolia@v1/api/graphql",
+    subsquid: "https://zero-x-markets.squids.live/0xmarkets-base-sepolia@v1/api/graphql",
   },
 };
 


### PR DESCRIPTION
Update the subsquid link to point to the live squid rather than an old deployment.