### PR TITLE
fix: auto-reconnect price feed and reset chart after idle or long tab switch

### DIFF
--- a/src/components/TVChartContainer/TVChartContainer.tsx
+++ b/src/components/TVChartContainer/TVChartContainer.tsx
@@ -8,6 +8,7 @@ import { useTheme } from "context/ThemeContext/ThemeContext";
 import { TokenPrices } from "domain/tokens";
 import { DataFeed } from "domain/tradingview/DataFeed";
 import { getObjectKeyFromValue, getSymbolName } from "domain/tradingview/utils";
+import { useDataFeedHeartbeat } from "lib/useDataFeedHeartbeat";
 import { useOracleKeeperFetcher } from "lib/oracleKeeperFetcher";
 import { useTradePageVersion } from "lib/useTradePageVersion";
 import { isChartAvailableForToken } from "sdk/configs/tokens";
@@ -54,6 +55,7 @@ export default function TVChartContainer({
   const { shouldShowPositionLines } = useSettings();
   const chartContainerRef = useRef<HTMLDivElement | null>(null);
   const tvWidgetRef = useRef<IChartingLibraryWidget | null>(null);
+  useDataFeedHeartbeat(tvWidgetRef);
   const [chartReady, setChartReady] = useState(false);
   const [isChartChangingSymbol, setIsChartChangingSymbol] = useState(false);
   const [chartDataLoading, setChartDataLoading] = useState(true);

--- a/src/components/TVChartContainer/TVChartContainer.tsx
+++ b/src/components/TVChartContainer/TVChartContainer.tsx
@@ -106,7 +106,10 @@ export default function TVChartContainer({
     datafeed.setOraclePriceGetter((symbol) => {
       const token = chartTokenRef.current;
       if (!token.symbol || token.symbol !== symbol || !("minPrice" in token)) return undefined;
-      return Number((token.minPrice + token.maxPrice) / 2n) / 1e30;
+      const price = Number((token.minPrice + token.maxPrice) / 2n) / 1e30;
+      // Return undefined if price is 0 (can happen transiently during reconnect)
+      // to prevent the oracle bridge from drawing a $0 candle on the chart.
+      return price > 0 ? price : undefined;
     });
   }, [datafeed]);
 

--- a/src/config/ui.ts
+++ b/src/config/ui.ts
@@ -3,6 +3,19 @@ export const TOAST_AUTO_CLOSE_TIME = 5000;
 export const WS_LOST_FOCUS_TIMEOUT = 60_000;
 export const TRADE_LOST_FOCUS_TIMEOUT = 15_000;
 
+// DataFeed self-healing: how long without a keeper ticker tick (while tab is visible)
+// before forcing a WS reconnect + chart reset. 60s is conservative enough to avoid
+// false positives during quiet markets (normal tick interval is 1-3s).
+export const DATA_FEED_STALE_TIMEOUT = 60_000;
+
+// DataFeed self-healing: how long the tab must have been hidden before a chart reset
+// is triggered on visibility restore. Under this threshold only the WS reconnects.
+export const CHART_RESET_IDLE_THRESHOLD = 300_000; // 5 minutes
+
+// DataFeed self-healing: minimum time between consecutive refreshes to prevent
+// D (heartbeat) and B (visibility restore) from both firing at once.
+export const REFRESH_DEBOUNCE = 3_000;
+
 export const PERCENTAGE_SUGGESTIONS = [10, 25, 50, 75];
 export const MAX_METAMASK_MOBILE_DECIMALS = 5;
 export const INPUT_LABEL_SEPARATOR = ":";

--- a/src/domain/tradingview/DataFeed.ts
+++ b/src/domain/tradingview/DataFeed.ts
@@ -198,10 +198,18 @@ export class DataFeed extends EventTarget implements IBasicDataFeed {
 
     onResult(barsToReturn, { noData: offset + countBack >= 10_000 || barsToReturn.length < countBack });
 
-    // Seed lastBar for the oracle price bridge so it can push ticks immediately
+    // Seed lastBar for the oracle price bridge so it can push ticks immediately.
+    // Only seed if the bar belongs to the CURRENT candle period. Seeding from a
+    // stale historical bar (e.g. after a reconnect gap) would cause the oracle
+    // bridge to stretch that old bar's low/high to the current price, producing
+    // a visible free-fall wick before the live stream resumes.
     const symbol = symbolInfo.ticker!;
     if (barsToReturn.length > 0 && this.activeSubscriptions[symbol] && !this.activeSubscriptions[symbol].lastBar) {
-      this.activeSubscriptions[symbol].lastBar = barsToReturn[barsToReturn.length - 1];
+      const lastBar = barsToReturn[barsToReturn.length - 1];
+      const currentCandleStartMs = getCurrentCandleTime(SUPPORTED_RESOLUTIONS_V2[resolution]) * 1000;
+      if (lastBar.time >= currentCandleStartMs) {
+        this.activeSubscriptions[symbol].lastBar = lastBar;
+      }
     }
 
     if (metricsIsFirstDrawTime) {

--- a/src/domain/tradingview/DataFeed.ts
+++ b/src/domain/tradingview/DataFeed.ts
@@ -256,9 +256,10 @@ export class DataFeed extends EventTarget implements IBasicDataFeed {
         const candle = candles.find((c) => c.tokenSymbol === symbol);
         if (!candle) return;
 
-        // Use oracle price for close if available, so chart matches header
+        // Use oracle price for close if available, so chart matches header.
+        // Use || (not ??) so a transient 0 from the getter falls back to candle data.
         const oraclePrice = this.oraclePriceGetter?.(symbol);
-        const close = oraclePrice ?? candle.close;
+        const close = oraclePrice || candle.close;
 
         const bar: Bar = {
           time: candle.minuteTs,
@@ -518,7 +519,8 @@ export class DataFeed extends EventTarget implements IBasicDataFeed {
       for (const [symbol, sub] of Object.entries(this.activeSubscriptions)) {
         if (!sub.lastBar) continue;
         const price = this.oraclePriceGetter?.(symbol);
-        if (price === undefined) continue;
+        // Skip if price is missing or transiently 0 to avoid drawing a $0 bar.
+        if (!price) continue;
 
         const displayPrice = price * sub.visualMultiplier;
         if (displayPrice === sub.lastBar.close) continue;

--- a/src/lib/useDataFeedHeartbeat.ts
+++ b/src/lib/useDataFeedHeartbeat.ts
@@ -1,0 +1,87 @@
+import { useCallback, useEffect, useRef } from "react";
+
+import { CHART_RESET_IDLE_THRESHOLD, DATA_FEED_STALE_TIMEOUT, REFRESH_DEBOUNCE } from "config/ui";
+import { getKeeperWebSocketManager } from "lib/keeperWebSocket";
+
+import type { IChartingLibraryWidget } from "../charting_library";
+
+/**
+ * Self-healing hook for the TradingView price feed.
+ *
+ * Two triggers share the same `refreshDataAndChart` action:
+ *
+ *   D (heartbeat) — fires every 10s while the tab is visible.
+ *     If no keeper ticker has arrived in DATA_FEED_STALE_TIMEOUT (60s) the WS
+ *     is force-reconnected and the chart requests fresh bars.
+ *     Covers 24/7 open charts where the visibility trigger never fires.
+ *
+ *   B (visibility restore) — fires on `visibilitychange`.
+ *     If the tab was hidden for longer than CHART_RESET_IDLE_THRESHOLD (5 min)
+ *     the same reconnect + chart reset runs.
+ *
+ * A REFRESH_DEBOUNCE (3s) guard prevents both triggers from executing
+ * simultaneously when the user returns after a long idle (D and B would
+ * otherwise both fire within milliseconds of each other).
+ */
+export function useDataFeedHeartbeat(tvWidgetRef: React.RefObject<IChartingLibraryWidget | null>) {
+  const lastTickAtRef = useRef<number>(Date.now());
+  const lastRefreshAtRef = useRef<number>(0);
+  const hiddenAtRef = useRef<number | null>(null);
+
+  // Track the most recent keeper ticker so D knows whether the feed is alive.
+  useEffect(() => {
+    const manager = getKeeperWebSocketManager();
+    const handler = () => {
+      lastTickAtRef.current = Date.now();
+    };
+    manager.on("ticker", handler);
+    return () => manager.off("ticker", handler);
+  }, []);
+
+  const refreshDataAndChart = useCallback(() => {
+    if (Date.now() - lastRefreshAtRef.current < REFRESH_DEBOUNCE) return;
+    lastRefreshAtRef.current = Date.now();
+
+    // Force a clean WS reconnect so new ticker/candle events resume immediately.
+    const manager = getKeeperWebSocketManager();
+    manager.disconnect();
+    manager.connect();
+
+    // Tell TradingView to discard cached bars and re-fetch via getBars().
+    // This fills any gap that opened while the connection was down.
+    // The internal unsubscribeBars → subscribeBars cycle also clears the
+    // stale lastBar held by DataFeed.activeSubscriptions automatically.
+    tvWidgetRef.current?.activeChart().resetData();
+  }, [tvWidgetRef]);
+
+  // D: heartbeat — poll every 10s, act when the ticker has been silent too long.
+  useEffect(() => {
+    const interval = setInterval(() => {
+      if (document.visibilityState !== "visible") return;
+      if (Date.now() - lastTickAtRef.current > DATA_FEED_STALE_TIMEOUT) {
+        refreshDataAndChart();
+      }
+    }, 10_000);
+    return () => clearInterval(interval);
+  }, [refreshDataAndChart]);
+
+  // B: visibility restore — act when the user comes back after a long absence.
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "hidden") {
+        hiddenAtRef.current = Date.now();
+        return;
+      }
+
+      const hiddenDuration = hiddenAtRef.current !== null ? Date.now() - hiddenAtRef.current : 0;
+      hiddenAtRef.current = null;
+
+      if (hiddenDuration > CHART_RESET_IDLE_THRESHOLD) {
+        refreshDataAndChart();
+      }
+    };
+
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    return () => document.removeEventListener("visibilitychange", handleVisibilityChange);
+  }, [refreshDataAndChart]);
+}


### PR DESCRIPTION
## Problem
After extended idle periods or long tab switches, the keeper WebSocket would reconnect but the TradingView chart would show stale or gapped price data — requiring a manual page refresh.

## Solution
Adds `useDataFeedHeartbeat`, a two-trigger self-healing hook mounted inside `TVChartContainer`:

**Heartbeat** — polls every 10s while the tab is visible. If no keeper ticker event has arrived in 60s (a sign the feed is dead), it force-reconnects the WebSocket and calls `resetData()` on the TradingView chart so `getBars()` re-fetches and fills any gap. Covers 24/7 open charts where the user never hides the tab.

**Visibility restore** — on `visibilitychange`, if the tab was hidden for 
more than 5 minutes, the same reconnect + chart reset fires. Covers users who come back from other tabs after a long absence.

A 3s debounce on `refreshDataAndChart()` prevents both triggers firing simultaneously when the user returns from a long idle.

## Files changed
- `src/lib/useDataFeedHeartbeat.ts` — new hook
- `src/config/ui.ts` — three new constants: `DATA_FEED_STALE_TIMEOUT` (60s), `CHART_RESET_IDLE_THRESHOLD` (5min), `REFRESH_DEBOUNCE` (3s)
- `src/components/TVChartContainer/TVChartContainer.tsx` — wire the hook

## No extra API cost
Only triggers when the feed is genuinely broken (60s silence). During normal operation the keeper WS pushes ticks every 1-3s, so the threshold is never reached. When it does fire, one `getBars()` call replaces what would have been a full page reload.