### PR TITLE
fix: bypass wallet RPC for eth_estimateGas in sendWalletTransaction

### DIFF
--- a/src/lib/transactions/sendWalletTransaction.ts
+++ b/src/lib/transactions/sendWalletTransaction.ts
@@ -72,16 +72,27 @@ export async function sendWalletTransaction({
       };
     }
 
-    const gasLimitPromise = gasLimit
+    // Estimate gas via our own RPC list instead of the wallet's RPC.
+    // Some Base Sepolia wallet RPCs (post-v1 reth nodes) reject
+    // eth_estimateGas with `intrinsic gas too high` (-32000) while
+    // eth_call against the same node succeeds, which surfaces in
+    // ethers v6 as a confusing `missing revert data` CALL_EXCEPTION.
+    // Routing estimation through our public/fallback RPC pool, plus a
+    // hardcoded ceiling, ensures we always send the tx with a gasLimit
+    // so the wallet never re-estimates internally against a broken node.
+    const provider = getProvider(undefined, chainId);
+
+    const FALLBACK_GAS_LIMIT = 5_000_000n;
+
+    const gasLimitPromise: Promise<bigint | number> = gasLimit
       ? Promise.resolve(gasLimit)
-      : estimateGasLimit(signer.provider!, {
+      : estimateGasLimit(provider, {
           to,
           from,
           data: callData,
           value,
-        }).catch(() => undefined);
+        }).catch(() => FALLBACK_GAS_LIMIT);
 
-    const provider = getProvider(undefined, chainId);
     const gasPriceDataPromise = gasPriceData
       ? Promise.resolve(gasPriceData)
       : getGasPrice(provider, chainId).catch(() => undefined);


### PR DESCRIPTION
Some Base Sepolia wallet RPCs (post-v1 base-reth-node) reject eth_estimateGas with `intrinsic gas too high` (-32000) while eth_call against the same node succeeds for the same tx. In ethers v6 this surfaces as a confusing `missing revert data` CALL_EXCEPTION inside estimateGasLimit's call fallback, blocking trades even though the contract logic is fine.

Route gas estimation through our own getProvider() RPC pool (public + fallback) instead of signer.provider, and fall back to a hardcoded 5M gas ceiling if estimation still fails. This guarantees we always pass a gasLimit to signer.sendTransaction so the wallet never re-estimates internally against a broken node.
